### PR TITLE
Support configuring allow-oasis-xml-catalog-pi

### DIFF
--- a/core/src/main/java/org/xmlresolver/Catalog.java
+++ b/core/src/main/java/org/xmlresolver/Catalog.java
@@ -156,6 +156,14 @@ public class Catalog {
         }
     }
 
+    /** Returns the configuration of this catalog
+     *
+     * @return Configuration of this catalog
+     */
+    public Configuration getConfiguration() {
+        return conf;
+    }
+
     // ======================================================================================================
     
     /** Returns the list of known catalog files.

--- a/core/src/main/java/org/xmlresolver/Configuration.java
+++ b/core/src/main/java/org/xmlresolver/Configuration.java
@@ -27,7 +27,11 @@ public class Configuration {
     }
 
     private static boolean isTrue(String aString) {
-        return "true".equalsIgnoreCase(aString) || "yes".equalsIgnoreCase(aString) || "1".equalsIgnoreCase(aString);
+        if (aString == null) {
+            return false;
+        } else {
+            return "true".equalsIgnoreCase(aString) || "yes".equalsIgnoreCase(aString) || "1".equalsIgnoreCase(aString);
+        }
     }
 
     public static Configuration create(String aPropertiesFiles) {
@@ -147,6 +151,11 @@ public class Configuration {
     public boolean queryPreferPublic() {
         String prefer = getProperty("xml.catalog.prefer", "prefer");
         return prefer == null || "public".equalsIgnoreCase(prefer);
+    }
+
+    public boolean queryAllowPI() {
+        String allowpi = getProperty("xml.catalog.allowPI", "allow-oasis-xml-catalog-pi");
+        return isTrue(allowpi);
     }
 
     public String queryCache() {

--- a/core/src/main/java/org/xmlresolver/ResourceConnection.java
+++ b/core/src/main/java/org/xmlresolver/ResourceConnection.java
@@ -118,7 +118,7 @@ public class ResourceConnection {
                 date = connection.getDate();
                 statusCode = 200;
             }
-        } catch (URISyntaxException | IOException use) {
+        } catch (URISyntaxException | IOException | IllegalArgumentException use) {
             // nop
         }
     }

--- a/core/src/main/java/org/xmlresolver/ResourceResolver.java
+++ b/core/src/main/java/org/xmlresolver/ResourceResolver.java
@@ -66,7 +66,7 @@ public class ResourceResolver {
      *
      * <p>By default, a static catalog initialized using the default properties is used by all ResourceResolvers.</p>
      */
-    public ResourceResolver() {
+    public  ResourceResolver() {
         init(getStaticCatalog());
     }
 

--- a/core/src/test/java/org/xmlresolver/tools/ResolvingXMLReaderTest.java
+++ b/core/src/test/java/org/xmlresolver/tools/ResolvingXMLReaderTest.java
@@ -10,11 +10,13 @@ package org.xmlresolver.tools;
 import junit.framework.TestCase;
 import org.xml.sax.SAXException;
 import org.xmlresolver.Catalog;
+import org.xmlresolver.Configuration;
 import org.xmlresolver.Resolver;
 
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.util.Properties;
 
 /**
  *
@@ -32,7 +34,7 @@ public class ResolvingXMLReaderTest extends TestCase {
     protected void tearDown() throws Exception {
     }
     
-    public void testReader() throws IOException, SAXException, TransformerException {
+    public void testReader() throws IOException, SAXException {
         SAXParserFactory spf = SAXParserFactory.newInstance();
         spf.setNamespaceAware(true);
         spf.setValidating(true);
@@ -46,5 +48,23 @@ public class ResolvingXMLReaderTest extends TestCase {
         assert(catalogList.contains("/doesnotexist.xml"));
         assert(catalogList.contains("/picat.xml"));
         assertNotNull(resolver.resolveEntity("", "pi.dtd"));
+    }
+
+    public void testForbiddenPI() throws IOException, SAXException {
+        Properties prop = new Properties();
+        prop.setProperty("allow-oasis-xml-catalog-pi", "false");
+        Configuration config = new Configuration(prop, null);
+        Catalog catalog = new Catalog(config, "dummy.cat");
+        Resolver resolver = new Resolver(catalog);
+
+        ResolvingXMLReader reader = new ResolvingXMLReader(resolver);
+        reader.parse("src/test/resources/documents/pitest-pass.xml");
+
+        resolver = reader.getResolver();
+        catalog = resolver.getCatalog();
+        String catalogList = catalog.catalogList();
+        assert(!catalogList.contains("/doesnotexist.xml"));
+        assert(!catalogList.contains("/picat.xml"));
+        assertNull(resolver.resolveEntity("", "pi.dtd"));
     }
 }

--- a/core/src/test/resources/documents/pitest-pass.xml
+++ b/core/src/test/resources/documents/pitest-pass.xml
@@ -1,0 +1,6 @@
+<?oasis-xml-catalog catalog='doesnotexist.xml'?>
+<?oasis-xml-catalog catalog='picat.xml'?>
+<!DOCTYPE doc PUBLIC "-//Example//DTD PI Document//EN" "doc.dtd">
+<doc>
+<p>Foo!</p>
+</doc>


### PR DESCRIPTION
1. Add support for disabling oasis-xml-catalog-pi in the configuration.
2. Update the filter to use that configuration change.
3. Added a test for the negative case.

Close #23 