### PR TITLE
Fix #47 by using a resolver to parse catalogs

### DIFF
--- a/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
@@ -9,10 +9,8 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 import org.xmlresolver.CatalogManager;
 import org.xmlresolver.Resolver;
-import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.ResolverLogger;
 import org.xmlresolver.Resource;
-import org.xmlresolver.XMLResolverConfiguration;
 import org.xmlresolver.catalog.entry.EntryCatalog;
 import org.xmlresolver.exceptions.CatalogInvalidException;
 import org.xmlresolver.exceptions.CatalogUnavailableException;
@@ -28,7 +26,6 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 
 /** A validating catalog loader.
@@ -44,14 +41,8 @@ public class ValidatingXmlLoader implements CatalogLoader {
     private final XmlLoader underlyingLoader;
 
     public ValidatingXmlLoader() {
-        XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
-        config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
-        config.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList("classpath:/org/xmlresolver/validator/catalog.xml"));
-        config.setFeature(ResolverFeature.CACHE_DIRECTORY, null);
-        config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
-        config.setFeature(ResolverFeature.ALLOW_CATALOG_PI, false);
-        resolver = new Resolver(config);
         underlyingLoader = new XmlLoader();
+        resolver = underlyingLoader.getLoaderResolver();
         catalogMap = new HashMap<>();
     }
 

--- a/src/test/java/org/xmlresolver/LoaderTest.java
+++ b/src/test/java/org/xmlresolver/LoaderTest.java
@@ -45,6 +45,28 @@ public class LoaderTest {
     }
 
     @Test
+    public void validatingDtd10ValidCatalog() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
+        config.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList("classpath:/dtd10catalog.xml"));
+        config.setFeature(ResolverFeature.CATALOG_LOADER_CLASS, "org.xmlresolver.loaders.ValidatingXmlLoader");
+        config.setFeature(ResolverFeature.CLASSPATH_CATALOGS, false);
+        CatalogManager manager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
+        URI rsrc = manager.lookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
+        assertNotNull(rsrc);
+    }
+
+    @Test
+    public void validatingDtd11ValidCatalog() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
+        config.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList("classpath:/dtd11catalog.xml"));
+        config.setFeature(ResolverFeature.CATALOG_LOADER_CLASS, "org.xmlresolver.loaders.ValidatingXmlLoader");
+        config.setFeature(ResolverFeature.CLASSPATH_CATALOGS, false);
+        CatalogManager manager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
+        URI rsrc = manager.lookupSystem("https://xmlresolver.org/ns/sample/sample.dtd");
+        assertNotNull(rsrc);
+    }
+
+    @Test
     public void validatingInvalidCatalog() {
         XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
         config.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList("classpath:/invalid-catalog.xml"));

--- a/src/test/resources/dtd10catalog.xml
+++ b/src/test/resources/dtd10catalog.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD XML Catalogs V1.0//EN"
+                  "http://www.oasis-open.org/committees/entity/release/1.0/catalog.dtd">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+  <public publicId="-//Sample//DTD Simple 1.0//EN"
+          uri="sample10/sample.dtd"/>
+
+  <system systemId="https://xmlresolver.org/ns/sample/sample.dtd"
+          uri="sample10/sample.dtd"/>
+</catalog>

--- a/src/test/resources/dtd11catalog.xml
+++ b/src/test/resources/dtd11catalog.xml
@@ -1,0 +1,11 @@
+<!DOCTYPE catalog PUBLIC "-//OASIS//DTD XML Catalogs V1.1//EN"
+                  "http://www.oasis-open.org/committees/entity/release/1.1/catalog.dtd">
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+  <public publicId="-//Sample//DTD Simple 1.0//EN"
+          uri="sample10/sample.dtd"/>
+
+  <system systemId="https://xmlresolver.org/ns/sample/sample.dtd"
+          uri="sample10/sample.dtd"/>
+</catalog>


### PR DESCRIPTION
The necessary catalog file was already present in the jar file, it just wasn't be used by the non-validating loader. But it does need to be used by that loader so that catalogs with doctype declarations can be parsed even if there's no internet connectivity.
