### PR TITLE
tests with local file references

### DIFF
--- a/src/test/java/org/xmlresolver/ResolverLocalFileTest.java
+++ b/src/test/java/org/xmlresolver/ResolverLocalFileTest.java
@@ -31,7 +31,7 @@ public class ResolverLocalFileTest {
     @Before
     public void setup() {
         config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog1));
-        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, false);
+        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
         config.setFeature(ResolverFeature.PREFER_PUBLIC, false);
         resolver = new Resolver(config);
     }
@@ -41,7 +41,7 @@ public class ResolverLocalFileTest {
         //this is what will get often get called by Saxon for a local file
         Source result = resolver.resolve("IVOA-v1.0.vo-dml.xml", "");
         assertNotNull("should have returned a source",result);
-        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+        assertEquals("file:/Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
     }
     
     @Test
@@ -49,14 +49,14 @@ public class ResolverLocalFileTest {
         //if the base is unknown then perhaps this should be the call..
         Source result = resolver.resolve("IVOA-v1.0.vo-dml.xml", null);
         assertNotNull("should have returned a source",result);
-        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+        assertEquals("file:/Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
     }
     @Test
     public void lookupLocalFileURI() throws TransformerException {
         //this is probably what clients should call for a local file to be compliant
         Source result = resolver.resolve("file://./IVOA-asurl.vo-dml.xml", null);
         assertNotNull("should have returned a source",result);
-        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+        assertEquals("file:/Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
 
     }
     
@@ -65,20 +65,10 @@ public class ResolverLocalFileTest {
         //this is probably what clients should call for a local file to be compliant
         Source result = resolver.resolve("file://./IVOA-asurl.vo-dml.xml", "");
         assertNotNull("should have returned a source",result);
-        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+        assertEquals("file:/Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
 
     }
-
-    
-    @Test
-    public void lookupNotInCatalogue() throws TransformerException {
-        //something not in the catalogue should just be returned if the resolver is to be used directly in saxon for instance
-        Source result = resolver.resolve("afile.ext", "file:///root/");
-        assertNotNull("should have returned a source",result);
-        assertEquals("file:///root/file.ext",result.getSystemId());
-      
-    }
-    
+     
     @Test
     public void URITest() throws URISyntaxException {
         URI uri = new URI("file://./IVOA-v1.0.vo-dml.xml");

--- a/src/test/java/org/xmlresolver/ResolverLocalFileTest.java
+++ b/src/test/java/org/xmlresolver/ResolverLocalFileTest.java
@@ -1,0 +1,89 @@
+/*
+ * Resolver2Test.java
+ * JUnit based test
+ *
+ * Created on January 2, 2007, 9:14 AM
+ */
+
+package org.xmlresolver;
+
+import static org.junit.Assert.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * Set of tests of using the catalogue and resolver on local files.
+ */
+public class ResolverLocalFileTest {
+    public static final String catalog1 = "src/test/resources/localfilecat.xml";
+    XMLResolverConfiguration config = null;
+    Resolver resolver = null;
+
+    @Before
+    public void setup() {
+        config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog1));
+        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, false);
+        config.setFeature(ResolverFeature.PREFER_PUBLIC, false);
+        resolver = new Resolver(config);
+    }
+
+    @Test
+    public void lookupLocalFile() throws TransformerException {
+        //this is what will get often get called by Saxon for a local file
+        Source result = resolver.resolve("IVOA-v1.0.vo-dml.xml", "");
+        assertNotNull("should have returned a source",result);
+        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+    }
+    
+    @Test
+    public void lookupLocalFileNull() throws TransformerException {
+        //if the base is unknown then perhaps this should be the call..
+        Source result = resolver.resolve("IVOA-v1.0.vo-dml.xml", null);
+        assertNotNull("should have returned a source",result);
+        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+    }
+    @Test
+    public void lookupLocalFileURI() throws TransformerException {
+        //this is probably what clients should call for a local file to be compliant
+        Source result = resolver.resolve("file://./IVOA-asurl.vo-dml.xml", null);
+        assertNotNull("should have returned a source",result);
+        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+
+    }
+    
+    @Test
+    public void lookupLocalFileURIblankBase() throws TransformerException {
+        //this is probably what clients should call for a local file to be compliant
+        Source result = resolver.resolve("file://./IVOA-asurl.vo-dml.xml", "");
+        assertNotNull("should have returned a source",result);
+        assertEquals("file:///Users/pharriso/Work/ivoa/vo-dml/models/ivoa/vo-dml/IVOA-v1.0.vo-dml.xml",result.getSystemId());
+
+    }
+
+    
+    @Test
+    public void lookupNotInCatalogue() throws TransformerException {
+        //something not in the catalogue should just be returned if the resolver is to be used directly in saxon for instance
+        Source result = resolver.resolve("afile.ext", "file:///root/");
+        assertNotNull("should have returned a source",result);
+        assertEquals("file:///root/file.ext",result.getSystemId());
+      
+    }
+    
+    @Test
+    public void URITest() throws URISyntaxException {
+        URI uri = new URI("file://./IVOA-v1.0.vo-dml.xml");
+        assertNotNull(uri);
+        System.out.println(uri.toString());
+    }
+    
+}

--- a/src/test/resources/localfilecat.xml
+++ b/src/test/resources/localfilecat.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<catalog  xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">  
+   <group  prefer="system"  xml:base="file:///Users/pharriso/Work/ivoa/vo-dml/models/" >  
+     <system
+         systemId="IVOA-v1.0.vo-dml.xml"  
+         uri="ivoa/vo-dml/IVOA-v1.0.vo-dml.xml"/>
+    <system
+         systemId="file://./IVOA-asurl.vo-dml.xml"  
+         uri="ivoa/vo-dml/IVOA-v1.0.vo-dml.xml"/>
+
+   </group>
+</catalog>

--- a/src/test/resources/localfilecat.xml
+++ b/src/test/resources/localfilecat.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <catalog  xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">  
    <group  prefer="system"  xml:base="file:///Users/pharriso/Work/ivoa/vo-dml/models/" >  
-     <system
-         systemId="IVOA-v1.0.vo-dml.xml"  
+     <uri
+         name="IVOA-v1.0.vo-dml.xml"  
          uri="ivoa/vo-dml/IVOA-v1.0.vo-dml.xml"/>
-    <system
-         systemId="file://./IVOA-asurl.vo-dml.xml"  
+     <uri
+         name="file://./IVOA-asurl.vo-dml.xml"  
          uri="ivoa/vo-dml/IVOA-v1.0.vo-dml.xml"/>
 
    </group>


### PR DESCRIPTION
These tests have local file references with a catalogue that translates
systemIds. None of the tests succeed - it might be the case that only
some of the tests are actually conformant with the expected arguments,
but it is certainly the case that Saxon (for example) will call with
such arguments.