### PR TITLE
Fix #59 where a non-XML-catalog catalog file caused an NPE

### DIFF
--- a/src/main/java/org/xmlresolver/loaders/XmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/XmlLoader.java
@@ -304,6 +304,7 @@ public class XmlLoader implements CatalogLoader {
                     }
                 } else {
                     logger.log(ResolverLogger.ERROR, "Catalog document is not an XML Catalog (ignored): " + qName);
+                    catalog = new EntryCatalog(baseURIStack.peek(), null, false);
                     parserStack.push(new EntryNull());
                 }
 

--- a/src/test/java/org/xmlresolver/tools/NotACatalogTest.java
+++ b/src/test/java/org/xmlresolver/tools/NotACatalogTest.java
@@ -1,0 +1,44 @@
+package org.xmlresolver.tools;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xmlresolver.Resolver;
+import org.xmlresolver.ResolverFeature;
+import org.xmlresolver.XMLResolverConfiguration;
+import org.xmlresolver.sources.ResolverInputSource;
+import org.xmlresolver.utils.URIUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collections;
+
+import static org.junit.Assert.*;
+
+public class NotACatalogTest {
+    public static final String catalog1 = "src/test/resources/notcatalog.xml";
+    XMLResolverConfiguration config = null;
+    Resolver resolver = null;
+
+    @Before
+    public void setup() {
+        config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog1));
+        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+        resolver = new Resolver(config);
+    }
+
+    @Test
+    public void lookupSystem() {
+        try {
+            // Test for https://github.com/xmlresolver/xmlresolver/issues/59
+            // It doesn't matter what we look up; the catalog isn't an XML catalog.
+            // But it should return null, not throw an NPE.
+            InputSource source = resolver.resolveEntity(null, "https://example.com/sample/1.0/sample.dtd");
+            assertNull(source);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+}

--- a/src/test/resources/notcatalog.xml
+++ b/src/test/resources/notcatalog.xml
@@ -1,0 +1,3 @@
+<doc>
+<para>This is an XML document, but it isn’t a catalog.</para>
+</doc>


### PR DESCRIPTION
Close #59 

When the XML catalog loader loaded an XML document that wasn't actually an XML Catalog, it left the `catalog` object null and subsequent attempts to resolve URIs against this catalog would always throw an NPE.

This fix assures that (an empty) catalog is returned. No attempt to resolve against this catalog will find any matching entries, of course, but it won't NPE, and resolution can continue to the next catalog, if there is one.
