### PR TITLE
Bump version to 3.1.3; 3.1.2 was a dud

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=3.1.1
+resolverVersion=3.1.3
 
 group=org.xmlresolver
 


### PR DESCRIPTION
I accidentally tagged 3.1.2 without bumping the version in `gradle.properties`. Rather than move a published tag, I'm just going to skip on by to 3.1.3.
