### PR TITLE
Release version 3.1.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=3.1.3
+resolverVersion=3.1.4
 
 group=org.xmlresolver
 


### PR DESCRIPTION
Apparently, I have things configured so that the `xmlresolverdata` release is built and distributed through Maven as part of the `xmlresolver` release. That's kind of sub-optimal since it means I need to do a new code release just to update the data jar file.

But that's what we're doing today.
