### PR TITLE
Add `getCatalogResolver()` to the `Resolver` object.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=3.1.6
+resolverVersion=3.1.7
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -85,6 +85,13 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
         return resolver.getConfiguration();
     }
 
+    /** Get the underlying {@link CatalogResolver} used by this resolver.
+     * @return The catalog resolver.
+     */
+    public CatalogResolver getCatalogResolver() {
+        return resolver;
+    }
+
     /** Implements the {@link javax.xml.transform.URIResolver} interface. */
     @Override
     public Source resolve(String href, String base) throws TransformerException {

--- a/src/test/java/org/xmlresolver/ClasspathTest.java
+++ b/src/test/java/org/xmlresolver/ClasspathTest.java
@@ -32,14 +32,16 @@ public class ClasspathTest {
     public static final List<String> catalogs = Arrays.asList("classpath:path/catalog.xml", "src/test/resources/cpcatalog.xml");
     public static XMLResolverConfiguration config = null;
     public static CatalogManager manager = null;
-    private static CatalogResolver resolver = null;
+    public static Resolver resolver = null;
+    private static CatalogResolver catresolver = null;
 
     @Before
     public void setup() {
         config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
         config.setFeature(ResolverFeature.CATALOG_FILES, catalogs);
         manager = new CatalogManager(config);
-        resolver = new CatalogResolver(config);
+        resolver = new Resolver(config);
+        catresolver = resolver.getCatalogResolver();
     }
 
     @Test
@@ -65,7 +67,7 @@ public class ClasspathTest {
 
         String line = null;
         try {
-            ResolvedResource result = resolver.resolveURI(href, null);
+            ResolvedResource result = catresolver.resolveURI(href, null);
             BufferedReader reader = new BufferedReader(new InputStreamReader(result.getInputStream()));
             line = reader.readLine();
         } catch (IOException ex) {
@@ -100,7 +102,7 @@ public class ClasspathTest {
 
         String line = null;
         try {
-            ResolvedResource result = resolver.resolveURI(href, null);
+            ResolvedResource result = catresolver.resolveURI(href, null);
             BufferedReader reader = new BufferedReader(new InputStreamReader(result.getInputStream()));
             line = reader.readLine();
         } catch (IOException ex) {
@@ -116,7 +118,7 @@ public class ClasspathTest {
 
         String line = null;
         try {
-            ResolvedResource result = resolver.resolveURI(href, base);
+            ResolvedResource result = catresolver.resolveURI(href, base);
             BufferedReader reader = new BufferedReader(new InputStreamReader(result.getInputStream()));
             line = reader.readLine();
         } catch (IOException ex) {
@@ -132,7 +134,7 @@ public class ClasspathTest {
 
         String line = null;
         try {
-            ResolvedResource result = resolver.resolveURI(href, base);
+            ResolvedResource result = catresolver.resolveURI(href, base);
             BufferedReader reader = new BufferedReader(new InputStreamReader(result.getInputStream()));
             line = reader.readLine();
         } catch (IOException ex) {

--- a/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
+++ b/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
@@ -12,13 +12,11 @@ import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-import org.xmlresolver.utils.URIUtils;
 
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
 import java.io.IOException;
-import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
Fix #70 
