### PR TITLE
Catch IllegalArgumentException, add THROW_URI_EXCEPTIONS feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=3.1.7
+resolverVersion=3.1.8
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/ResolverFeature.java
+++ b/src/main/java/org/xmlresolver/ResolverFeature.java
@@ -278,4 +278,16 @@ public class ResolverFeature<T> {
      */
     public static final ResolverFeature<Boolean> ARCHIVED_CATALOGS = new ResolverFeature<>(
             "http://xmlresolver.org/feature/archived-catalogs", true);
+
+    /**
+     * Allows the resolver to throw exceptions for invalid URIs.
+     *
+     * <p>If enabled, when the resolver attempts to process a URI, if the processing
+     * raises an exception, that exception will be thrown rather than suppressed. For
+     * checked exceptions, such as <code>URISyntaxException</code>, what's thrown will
+     * be a <code>IllegalArgumentException</code> wrapping the underlying exception.</p>
+     */
+    public static final ResolverFeature<Boolean> THROW_URI_EXCEPTIONS = new ResolverFeature<>(
+            "http://xmlresolver.org/feature/throw-uri-exceptions", false);
+
 }

--- a/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
+++ b/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
@@ -135,7 +135,7 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             ResolverFeature.CATALOG_MANAGER, ResolverFeature.URI_FOR_SYSTEM,
             ResolverFeature.CATALOG_LOADER_CLASS, ResolverFeature.PARSE_RDDL,
             ResolverFeature.CLASSPATH_CATALOGS, ResolverFeature.CLASSLOADER,
-            ResolverFeature.ARCHIVED_CATALOGS};
+            ResolverFeature.ARCHIVED_CATALOGS, ResolverFeature.THROW_URI_EXCEPTIONS};
 
     private static List<String> classpathCatalogList = null;
 
@@ -156,6 +156,7 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
     private Boolean classpathCatalogs = ResolverFeature.CLASSPATH_CATALOGS.getDefaultValue();
     private ClassLoader classLoader = ResolverFeature.CLASSLOADER.getDefaultValue();
     private Boolean archivedCatalogs = ResolverFeature.ARCHIVED_CATALOGS.getDefaultValue();
+    private Boolean throwUriExceptions = ResolverFeature.THROW_URI_EXCEPTIONS.getDefaultValue();
     private Boolean showConfigChanges = false; // make the config process a bit less chatty
 
     /** Construct a default configuration.
@@ -247,6 +248,7 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         parseRddl = current.parseRddl;
         classpathCatalogs = current.classpathCatalogs;
         archivedCatalogs = current.archivedCatalogs;
+        throwUriExceptions = current.throwUriExceptions;
         showConfigChanges = current.showConfigChanges;
     }
 
@@ -421,6 +423,12 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             showConfigChange("Archived catalogs: %s", property);
             archivedCatalogs = isTrue(property);
         }
+
+        property = System.getProperty("xml.catalog.throwUriExceptions");
+        if (property != null) {
+            showConfigChange("Throw URI exceptions: %s", property);
+            throwUriExceptions = isTrue(property);
+        }
     }
 
     private void loadPropertiesConfiguration(URL propertiesURL, Properties properties) {
@@ -551,6 +559,12 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             showConfigChange("Archived catalogs: %s", property);
             archivedCatalogs = isTrue(property);
         }
+
+        property = properties.getProperty("throw-uri-exceptions");
+        if (property != null) {
+            showConfigChange("Throw URI exceptions: %s", property);
+            throwUriExceptions = isTrue(property);
+        }
     }
 
     private void showConfig() {
@@ -567,6 +581,7 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         logger.log(ResolverLogger.CONFIG, "Catalog loader: %s", catalogLoader);
         logger.log(ResolverLogger.CONFIG, "Classpath catalogs: %s", classpathCatalogs);
         logger.log(ResolverLogger.CONFIG, "Archived catalogs: %s", archivedCatalogs);
+        logger.log(ResolverLogger.CONFIG, "Throw URI exceptions: %s", throwUriExceptions);
         logger.log(ResolverLogger.CONFIG, "Class loader: %s", classLoader);
         for (String catalog: catalogs) {
             logger.log(ResolverLogger.CONFIG, "Catalog: %s", catalog);
@@ -731,6 +746,9 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         } else if (feature == ResolverFeature.ARCHIVED_CATALOGS) {
             archivedCatalogs = (Boolean) value;
             showConfigChange("Archived catalogs: %s", archivedCatalogs);
+        } else if (feature == ResolverFeature.THROW_URI_EXCEPTIONS) {
+            throwUriExceptions = (Boolean) value;
+            showConfigChange("Throw URI exceptions: %s", throwUriExceptions);
         } else {
             logger.log(ResolverLogger.ERROR, "Ignoring unknown feature: %s", feature.getName());
         }
@@ -846,6 +864,8 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             return (T) classLoader;
         } else if (feature == ResolverFeature.ARCHIVED_CATALOGS) {
             return (T) archivedCatalogs;
+        } else if (feature == ResolverFeature.THROW_URI_EXCEPTIONS) {
+            return (T) throwUriExceptions;
         } else {
             logger.log(ResolverLogger.ERROR, "Ignoring unknown feature: %s", feature.getName());
             return null;

--- a/src/test/java/org/xmlresolver/ResolverTest.java
+++ b/src/test/java/org/xmlresolver/ResolverTest.java
@@ -22,10 +22,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -69,6 +66,30 @@ public class ResolverTest {
         } catch (IOException | SAXException ex) {
             fail();
         }
+    }
+
+    @Test
+    public void throwUriExceptions() {
+        boolean throwExceptions = config.getFeature(ResolverFeature.THROW_URI_EXCEPTIONS);
+        try {
+            config.setFeature(ResolverFeature.THROW_URI_EXCEPTIONS, false);
+            URIUtils.cwd().resolve("src/test/resources/sample10/sample.dtd");
+            InputSource source = resolver.resolveEntity(null, "blort%gg");
+            assertNull(source);
+        } catch (IOException | SAXException ex) {
+            fail();
+        }
+
+        try {
+            config.setFeature(ResolverFeature.THROW_URI_EXCEPTIONS, true);
+            URIUtils.cwd().resolve("src/test/resources/sample10/sample.dtd");
+            resolver.resolveEntity(null, "blort%gg");
+            fail();
+        } catch (IOException | SAXException | IllegalArgumentException ex) {
+            // pass;
+        }
+
+        config.setFeature(ResolverFeature.THROW_URI_EXCEPTIONS, throwExceptions);
     }
 
     @Test


### PR DESCRIPTION
Fix #72 

The resolver now properly catches `IllegalArgumentException` as a resolution failure.

If the new `ResolverFeature.THROW_URI_EXCEPTIONS` feature is `true`, exceptions raised by the URI class will be thrown. The `URISyntaxException` will be wrapped in an `IllegalArgumentException`.

The default for the feature is `false`. 