### PR TITLE
Refactor to make logging behavior simpler for users

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=3.1.8
+resolverVersion=4.0.0
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -6,6 +6,8 @@ import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.EntityResolver2;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
 import org.xmlresolver.sources.ResolverInputSource;
 import org.xmlresolver.sources.ResolverLSInput;
 import org.xmlresolver.sources.ResolverSAXSource;
@@ -36,15 +38,18 @@ import java.io.IOException;
  */
 
 public class Resolver implements URIResolver, EntityResolver, EntityResolver2, NamespaceResolver, LSResourceResolver {
-    private static final ResolverLogger logger = new ResolverLogger(Resolver.class);
-    protected CatalogResolver resolver = null;
+    private final ResolverLogger logger;
+    protected final XMLResolverConfiguration config;
+    protected final CatalogResolver resolver;
 
     /** Creates a new instance of Resolver.
      *
      * The default resolver is a new ResourceResolver that uses a static catalog shared by all threads.
      */
     public Resolver() {
-        resolver = new CatalogResolver();
+        config = new XMLResolverConfiguration();
+        resolver = new CatalogResolver(config);
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** Creates a new instance of a Resolver.
@@ -54,7 +59,9 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
      * @param config The configuration to use.
      */
     public Resolver(XMLResolverConfiguration config) {
+        this.config = config;
         resolver = new CatalogResolver(config);
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** Creates a new instance of a Resolver.
@@ -64,7 +71,9 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
      * @param resolver The resource resolver to use.
      */
     public Resolver(CatalogResolver resolver) {
+        config = resolver.getConfiguration();
         this.resolver = resolver;
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** What version is this?
@@ -110,11 +119,11 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
     public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
         ResolvedResource rsrc = null;
         if (type == null || "http://www.w3.org/TR/REC-xml".equals(type)) {
-            logger.log(ResolverLogger.REQUEST, "resolveResource: XML: %s (baseURI: %s, publicId: %s)",
+            logger.log(AbstractLogger.REQUEST, "resolveResource: XML: %s (baseURI: %s, publicId: %s)",
                     systemId, baseURI, publicId);
             rsrc = resolver.resolveEntity(null, publicId, systemId, baseURI);
         } else {
-            logger.log(ResolverLogger.REQUEST, "resolveResource: %s, %s (namespace: %s, baseURI: %s, publicId: %s)",
+            logger.log(AbstractLogger.REQUEST, "resolveResource: %s, %s (namespace: %s, baseURI: %s, publicId: %s)",
                     type, systemId, namespaceURI, baseURI, publicId);
 
             String purpose = null;

--- a/src/main/java/org/xmlresolver/ResolverFeature.java
+++ b/src/main/java/org/xmlresolver/ResolverFeature.java
@@ -1,6 +1,7 @@
 package org.xmlresolver;
 
 import org.xmlresolver.cache.ResourceCache;
+import org.xmlresolver.logging.ResolverLogger;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -267,7 +268,7 @@ public class ResolverFeature<T> {
      * loader is required, you can specify it with this feature.</p>
      */
     public static final ResolverFeature<ClassLoader> CLASSLOADER = new ResolverFeature<>(
-            "http://xmlresolver.org/feature/classloader", (ClassLoader) null);
+            "http://xmlresolver.org/feature/classloader", null);
 
     /**
      * Adds support for placing ZIP files on the catalog path.
@@ -289,5 +290,37 @@ public class ResolverFeature<T> {
      */
     public static final ResolverFeature<Boolean> THROW_URI_EXCEPTIONS = new ResolverFeature<>(
             "http://xmlresolver.org/feature/throw-uri-exceptions", false);
+
+    /**
+     * Identifies the resolver logger class.
+     *
+     * <p>The {@link org.xmlresolver.logging.DefaultLogger DefaultLogger} class writes log messages
+     * to <code>System.err</code>. The {@link org.xmlresolver.logging.SystemLogger SystemLogger} uses
+     * a logging backend. (You must configure a concrete backend for the logging facade on your
+     * classpath.)</p>
+     */
+    public static final ResolverFeature<String> RESOLVER_LOGGER_CLASS = new ResolverFeature<>(
+            "http://xmlresolver.org/feature/resolver-logger-class", "org.xmlresolver.logging.DefaultLogger");
+
+    /**
+     * Identifies the resolver logger.
+     *
+     * <p>This feature can get and set an instance of the logger. The logger is usually
+     * configured with the <code>RESOLVER_LOGGER_CLASS</code> feature. If the logger
+     * has been configured that way, an attempt to get the <code>RESOLVER_LOGGER</code>
+     * should instantiate the class.</p>
+     */
+    public static final ResolverFeature<ResolverLogger> RESOLVER_LOGGER = new ResolverFeature<>(
+            "http://xmlresolver.org/feature/resolver-logger", null);
+
+    /**
+     * Specify the logging level for the default logger.
+     *
+     * <p>This feature only applies to the {@link org.xmlresolver.logging.DefaultLogger} (or other classes
+     * that use it). In particular, it has no effect if the {@link org.xmlresolver.logging.SystemLogger} is used.
+     * How that is configured depends on the concrete backend selected at runtime.</p>
+     */
+    public static final ResolverFeature<String> DEFAULT_LOGGER_LOG_LEVEL = new ResolverFeature<>(
+            "http://xmlresolver.org/feature/default-logger-log-level", "warn");
 
 }

--- a/src/main/java/org/xmlresolver/ResourceConnection.java
+++ b/src/main/java/org/xmlresolver/ResourceConnection.java
@@ -10,6 +10,8 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIUtils;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,8 +26,6 @@ import java.util.Date;
 import java.util.List;
 
 public class ResourceConnection {
-    private static final ResolverLogger logger = new ResolverLogger(ResourceConnection.class);
-
     private InputStream stream = null;
     private URI uri = null;
     private URI redirect = null;
@@ -40,11 +40,11 @@ public class ResourceConnection {
     // ResourceConnection logic in multiple places. To check properties, I only
     // want to make a HEAD request, so ...
 
-    public ResourceConnection(String resolved) {
-        this(resolved, false);
+    public ResourceConnection(ResolverConfiguration config, String resolved) {
+        this(config, resolved, false);
     }
 
-    public ResourceConnection(String resolved, boolean headOnly) {
+    public ResourceConnection(ResolverConfiguration config, String resolved, boolean headOnly) {
         try {
             uri = org.xmlresolver.utils.URIUtils.newURI(resolved);
             URL url = uri.toURL();
@@ -123,7 +123,8 @@ public class ResourceConnection {
                 }
             }
         } catch (URISyntaxException | IOException | IllegalArgumentException use) {
-            logger.log(ResolverLogger.WARNING, "Failed to %s: %s: %s", headOnly ? "HEAD" : "GET", resolved, use.getMessage());
+            ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+            logger.log(AbstractLogger.WARNING, "Failed to %s: %s: %s", headOnly ? "HEAD" : "GET", resolved, use.getMessage());
         }
     }
 

--- a/src/main/java/org/xmlresolver/StAXResolver.java
+++ b/src/main/java/org/xmlresolver/StAXResolver.java
@@ -9,6 +9,9 @@
 
 package org.xmlresolver;
 
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
+
 import javax.xml.stream.XMLResolver;
 import javax.xml.stream.XMLStreamException;
 
@@ -28,7 +31,7 @@ import javax.xml.stream.XMLStreamException;
  *
  */
 public class StAXResolver implements XMLResolver {
-    protected static ResolverLogger logger = new ResolverLogger(StAXResolver.class);
+    protected final ResolverLogger logger;
     ResourceResolver resolver = null;
     
     /** Creates a new instance of StAXResolver.
@@ -36,7 +39,9 @@ public class StAXResolver implements XMLResolver {
      * The default resolver is a new ResourceResolver that uses a static catalog shared by all threads.
      */
     public StAXResolver() {
-        resolver = new CatalogResolver();
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        resolver = new CatalogResolver(config);
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** Creates a new instance of a StAXResolver.
@@ -47,6 +52,7 @@ public class StAXResolver implements XMLResolver {
      */
     public StAXResolver(XMLResolverConfiguration config) {
         resolver = new CatalogResolver(config);
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** Creates a new instance of a StAXResolver.
@@ -57,6 +63,8 @@ public class StAXResolver implements XMLResolver {
      */
     public StAXResolver(ResourceResolver resolver) {
         this.resolver = resolver;
+        logger = resolver.getConfiguration().getFeature(ResolverFeature.RESOLVER_LOGGER);
+
     }
 
     /** Get the configuration used by this resolver.
@@ -69,17 +77,17 @@ public class StAXResolver implements XMLResolver {
 
     /** Implements the {@link javax.xml.stream.XMLResolver} interface. */
     public Object resolveEntity(String publicId, String systemId, String baseURI, String namespace) throws XMLStreamException {
-        logger.log(ResolverLogger.REQUEST, "resolveEntity: %s/%s (baseURI: %s, %s)",
+        logger.log(AbstractLogger.REQUEST, "resolveEntity: %s/%s (baseURI: %s, %s)",
                 systemId, namespace, baseURI, publicId);
 
         ResolvedResource rsrc = resolver.resolveEntity(null, publicId, systemId, baseURI);
 
         if (rsrc == null) {
-            logger.log(ResolverLogger.RESPONSE, "resolvedEntity: %s/%s (baseURI: %s, %s) → null",
+            logger.log(AbstractLogger.RESPONSE, "resolvedEntity: %s/%s (baseURI: %s, %s) → null",
                     systemId, namespace, baseURI, publicId);
             return null;
         } else {
-            logger.log(ResolverLogger.RESPONSE, "resolvedEntity: %s/%s (baseURI: %s, %s) → %s",
+            logger.log(AbstractLogger.RESPONSE, "resolvedEntity: %s/%s (baseURI: %s, %s) → %s",
                     systemId, namespace, baseURI, publicId, rsrc.getResolvedURI());
             return rsrc.getInputStream();
         }

--- a/src/main/java/org/xmlresolver/cache/CacheEntryCatalog.java
+++ b/src/main/java/org/xmlresolver/cache/CacheEntryCatalog.java
@@ -1,12 +1,13 @@
 package org.xmlresolver.cache;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.ResolverConstants;
-import org.xmlresolver.ResolverLogger;
 import org.xmlresolver.catalog.entry.Entry;
 import org.xmlresolver.catalog.entry.EntryCatalog;
 import org.xmlresolver.catalog.entry.EntryPublic;
 import org.xmlresolver.catalog.entry.EntrySystem;
 import org.xmlresolver.catalog.entry.EntryUri;
+import org.xmlresolver.logging.AbstractLogger;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -26,8 +27,8 @@ public class CacheEntryCatalog extends EntryCatalog {
     public final ArrayList<CacheEntry> cached = new ArrayList<>();
     private final URI baseURI;
 
-    public CacheEntryCatalog(URI baseURI, String id, boolean prefer) {
-        super(baseURI, id, prefer);
+    public CacheEntryCatalog(ResolverConfiguration config, URI baseURI, String id, boolean prefer) {
+        super(config, baseURI, id, prefer);
         this.baseURI = baseURI;
     }
 
@@ -77,13 +78,13 @@ public class CacheEntryCatalog extends EntryCatalog {
         sb.append(":");
         Formatter formatter = new Formatter(sb);
         formatter.format(message, params);
-        logger.log(ResolverLogger.CACHE, sb.toString());
+        logger.log(AbstractLogger.CACHE, sb.toString());
     }
 
     protected EntryUri addUri(URI baseURI, String name, String uri, String nature, String purpose, long timestamp) {
         EntryUri entry = null;
         if (name != null && uri != null) {
-            entry = new EntryUri(baseURI, null, name, uri, nature, purpose);
+            entry = new EntryUri(config, baseURI, null, name, uri, nature, purpose);
             add(entry, timestamp);
         } else {
             error("Invalid uri entry (missing name or uri attribute)");
@@ -95,7 +96,7 @@ public class CacheEntryCatalog extends EntryCatalog {
     protected EntryPublic addPublic(URI baseURI, String publicId, String uri, long timestamp) {
         EntryPublic entry = null;
         if (publicId != null && uri != null) {
-            entry = new EntryPublic(baseURI, null, publicId, uri, true);
+            entry = new EntryPublic(config, baseURI, null, publicId, uri, true);
             add(entry, timestamp);
         } else {
             error("Invalid public entry (missing publicId or uri attribute)");
@@ -106,7 +107,7 @@ public class CacheEntryCatalog extends EntryCatalog {
     protected EntrySystem addSystem(URI baseURI, String systemId, String uri, long timestamp) {
         EntrySystem entry = null;
         if (systemId != null && uri != null) {
-            entry = new EntrySystem(baseURI, null, systemId, uri);
+            entry = new EntrySystem(config, baseURI, null, systemId, uri);
             add(entry, timestamp);
         } else {
             error("Invalid system entry (missing systemId or uri attribute)");
@@ -191,7 +192,7 @@ public class CacheEntryCatalog extends EntryCatalog {
                 }
                 newTypedEntries.get(entry.entry.getType()).add(entry.entry);
             } else {
-                logger.log(ResolverLogger.CACHE, "Expiring %s (%s)", entry.file.getAbsolutePath(), entry.uri);
+                logger.log(AbstractLogger.CACHE, "Expiring %s (%s)", entry.file.getAbsolutePath(), entry.uri);
                 entry.expired = true;
                 File entryFile = new File(entry.entry.baseURI);
                 Path source = entryFile.toPath();
@@ -199,7 +200,7 @@ public class CacheEntryCatalog extends EntryCatalog {
                 try {
                     Files.move(source, target, REPLACE_EXISTING);
                 } catch (IOException ex) {
-                    logger.log(ResolverLogger.ERROR, "Attempt to expire cache entry failed: %s: %s",
+                    logger.log(AbstractLogger.ERROR, "Attempt to expire cache entry failed: %s: %s",
                             entry.file.getAbsolutePath(), ex.getMessage());
                 }
             }

--- a/src/main/java/org/xmlresolver/cache/CacheParser.java
+++ b/src/main/java/org/xmlresolver/cache/CacheParser.java
@@ -1,6 +1,9 @@
 package org.xmlresolver.cache;
 
-import org.xmlresolver.ResolverLogger;
+import org.xmlresolver.ResolverConfiguration;
+import org.xmlresolver.ResolverFeature;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
 
 import java.util.regex.Pattern;
 
@@ -8,7 +11,7 @@ import java.util.regex.Pattern;
  *
  */
 public class CacheParser {
-    protected static ResolverLogger logger = new ResolverLogger(CacheParser.class);
+    protected final ResolverLogger logger;
 
     private static final Pattern sizeK = Pattern.compile("^[0-9]+k$", Pattern.CASE_INSENSITIVE);
     private static final Pattern sizeM = Pattern.compile("^[0-9]+m$", Pattern.CASE_INSENSITIVE);
@@ -19,7 +22,11 @@ public class CacheParser {
     private static final Pattern timeD = Pattern.compile("^[0-9]+d$", Pattern.CASE_INSENSITIVE);
     private static final Pattern timeW = Pattern.compile("^[0-9]+w$", Pattern.CASE_INSENSITIVE);
 
-    public static long parseLong(String longStr, long defVal) {
+    public CacheParser(ResolverConfiguration config) {
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+    }
+
+    public long parseLong(String longStr, long defVal) {
         if (longStr == null) {
             return defVal;
         }
@@ -27,12 +34,12 @@ public class CacheParser {
         try {
             return Long.parseLong(longStr);
         } catch (NumberFormatException nfe) {
-            logger.log(ResolverLogger.ERROR, "Bad numeric value: %s", longStr);
+            logger.log(AbstractLogger.ERROR, "Bad numeric value: %s", longStr);
             return defVal;
         }
     }
 
-    public static long parseSizeLong(String longStr, long defVal) {
+    public long parseSizeLong(String longStr, long defVal) {
         if (longStr == null) {
             return defVal;
         }
@@ -52,7 +59,7 @@ public class CacheParser {
         return parseLong(longStr, units, defVal);
     }
 
-    public static long parseTimeLong(String longStr, long defVal) {
+    public long parseTimeLong(String longStr, long defVal) {
         if (longStr == null) {
             return defVal;
         }
@@ -77,12 +84,12 @@ public class CacheParser {
         return parseLong(longStr, units, defVal);
     }
 
-    public static long parseLong(String longStr, long units, long defVal) {
+    public long parseLong(String longStr, long units, long defVal) {
         try {
             long val = Long.parseLong(longStr);
             return val * units;
         } catch (NumberFormatException nfe) {
-            logger.log(ResolverLogger.ERROR, "Bad numeric value: %s", longStr);
+            logger.log(AbstractLogger.ERROR, "Bad numeric value: %s", longStr);
             return defVal;
         }
     }

--- a/src/main/java/org/xmlresolver/catalog/entry/Entry.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/Entry.java
@@ -1,6 +1,9 @@
 package org.xmlresolver.catalog.entry;
 
-import org.xmlresolver.ResolverLogger;
+import org.xmlresolver.ResolverConfiguration;
+import org.xmlresolver.ResolverFeature;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -8,7 +11,9 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 public abstract class Entry {
-    public static ResolverLogger logger = new ResolverLogger(Entry.class);
+    protected final ResolverLogger logger;
+    protected final ResolverConfiguration config;
+
     public enum Type {
         NULL, CATALOG, DELEGATE_PUBLIC, DELEGATE_SYSTEM, DELEGATE_URI,
         DOCTYPE, DOCUMENT, DTD_DECL,ENTITY, GROUP, LINKTYPE, NEXT_CATALOG,
@@ -25,20 +30,22 @@ public abstract class Entry {
     public final String id;
     public final HashMap<String,String> extra = new HashMap<>();
 
-    public Entry(URI baseURI, String id) {
+    public Entry(ResolverConfiguration config, URI baseURI, String id) {
         this.id = id;
         if (baseURI.isAbsolute()) {
             this.baseURI = baseURI;
         } else {
             throw new IllegalArgumentException("Base URI of catalog entry must be absolute: " + baseURI);
         }
+        this.config = config;
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     public void setProperty(String name, String value) {
         if (NCNAME_RE.matcher(name).matches()) {
             extra.put(name, value);
         } else {
-            logger.log(ResolverLogger.ERROR, "Property name invalid: " + name);
+            logger.log(AbstractLogger.ERROR, "Property name invalid: " + name);
         }
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryCatalog.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryCatalog.java
@@ -1,7 +1,8 @@
 package org.xmlresolver.catalog.entry;
 
 import org.xml.sax.Locator;
-import org.xmlresolver.ResolverLogger;
+import org.xmlresolver.ResolverConfiguration;
+import org.xmlresolver.logging.AbstractLogger;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -10,15 +11,14 @@ import java.util.HashMap;
 import java.util.List;
 
 public class EntryCatalog extends Entry {
-    public static ResolverLogger logger = new ResolverLogger(EntryCatalog.class);
     public final boolean preferPublic;
     protected static final ArrayList<Entry> none = new ArrayList<>();
     protected final ArrayList<Entry> entries = new ArrayList<> ();
     protected final HashMap<Type, ArrayList<Entry>> typedEntries = new HashMap<>();
     protected Locator locator = null;
 
-    public EntryCatalog(URI baseURI, String id, boolean prefer) {
-        super(baseURI, id);
+    public EntryCatalog(ResolverConfiguration config, URI baseURI, String id, boolean prefer) {
+        super(config, baseURI, id);
         this.preferPublic = prefer;
     }
 
@@ -69,11 +69,11 @@ public class EntryCatalog extends Entry {
         sb.append(":");
         Formatter formatter = new Formatter(sb);
         formatter.format(message, params);
-        logger.log(ResolverLogger.ERROR, sb.toString());
+        logger.log(AbstractLogger.ERROR, sb.toString());
     }
 
     public EntryGroup addGroup(URI baseURI, String id, boolean prefer) {
-        EntryGroup entry = new EntryGroup(baseURI, id, prefer);
+        EntryGroup entry = new EntryGroup(config, baseURI, id, prefer);
         add(entry);
         return entry;
     }
@@ -81,7 +81,7 @@ public class EntryCatalog extends Entry {
     public EntryPublic addPublic(URI baseURI, String id, String publicId, String uri, boolean prefer) {
         EntryPublic entry = null;
         if (publicId != null && uri != null) {
-            entry = new EntryPublic(baseURI, id, publicId, uri, prefer);
+            entry = new EntryPublic(config, baseURI, id, publicId, uri, prefer);
             add(entry);
         } else {
             error("Invalid public entry (missing publicId or uri attribute)");
@@ -92,7 +92,7 @@ public class EntryCatalog extends Entry {
     public EntrySystem addSystem(URI baseURI, String id, String systemId, String uri) {
         EntrySystem entry = null;
         if (systemId != null && uri != null) {
-            entry = new EntrySystem(baseURI, id, systemId, uri);
+            entry = new EntrySystem(config, baseURI, id, systemId, uri);
             add(entry);
         } else {
             error("Invalid system entry (missing systemId or uri attribute)");
@@ -103,7 +103,7 @@ public class EntryCatalog extends Entry {
     public EntrySystemSuffix addSystemSuffix(URI baseURI, String id, String suffix, String uri) {
         EntrySystemSuffix entry = null;
         if (suffix != null && uri != null) {
-            entry = new EntrySystemSuffix(baseURI, id, suffix, uri);
+            entry = new EntrySystemSuffix(config, baseURI, id, suffix, uri);
             add(entry);
         } else {
             error("Invalid systemSuffix entry (missing systemIdSuffix or uri attribute)");
@@ -114,7 +114,7 @@ public class EntryCatalog extends Entry {
     public EntryRewriteSystem addRewriteSystem(URI baseURI, String id, String startString, String prefix) {
         EntryRewriteSystem entry = null;
         if (startString != null && prefix != null) {
-            entry = new EntryRewriteSystem(baseURI, id, startString, prefix);
+            entry = new EntryRewriteSystem(config, baseURI, id, startString, prefix);
             add(entry);
         } else {
             error("Invalid rewriteSystem entry (missing systemIdStartString or prefix attribute)");
@@ -125,7 +125,7 @@ public class EntryCatalog extends Entry {
     public EntryDelegateSystem addDelegateSystem(URI baseURI, String id, String startString, String catalog) {
         EntryDelegateSystem entry = null;
         if (startString != null && catalog != null) {
-            entry = new EntryDelegateSystem(baseURI, id, startString, catalog);
+            entry = new EntryDelegateSystem(config, baseURI, id, startString, catalog);
             add(entry);
         } else {
             error("Invalid delegateSystem entry (missing systemIdStartString or catalog attribute)");
@@ -136,7 +136,7 @@ public class EntryCatalog extends Entry {
     public EntryDelegatePublic addDelegatePublic(URI baseURI, String id, String startString, String catalog, boolean prefer) {
         EntryDelegatePublic entry = null;
         if (startString != null && catalog != null) {
-            entry = new EntryDelegatePublic(baseURI, id, startString, catalog, prefer);
+            entry = new EntryDelegatePublic(config, baseURI, id, startString, catalog, prefer);
             add(entry);
         } else {
             error("Invalid delegatePublic entry (missing publicIdStartString or catalog attribute)");
@@ -147,7 +147,7 @@ public class EntryCatalog extends Entry {
     public EntryUri addUri(URI baseURI, String id, String name, String uri, String nature, String purpose) {
         EntryUri entry = null;
         if (name != null && uri != null) {
-            entry = new EntryUri(baseURI, id, name, uri, nature, purpose);
+            entry = new EntryUri(config, baseURI, id, name, uri, nature, purpose);
             add(entry);
         } else {
             error("Invalid uri entry (missing name or uri attribute)");
@@ -158,7 +158,7 @@ public class EntryCatalog extends Entry {
     public EntryRewriteUri addRewriteUri(URI baseURI, String id, String start, String prefix) {
         EntryRewriteUri entry = null;
         if (start != null && prefix != null) {
-            entry = new EntryRewriteUri(baseURI, id, start, prefix);
+            entry = new EntryRewriteUri(config, baseURI, id, start, prefix);
             add(entry);
         } else {
             error("Invalid rewriteURI entry (missing uriStartString or prefix attribute)");
@@ -169,7 +169,7 @@ public class EntryCatalog extends Entry {
     public EntryUriSuffix addUriSuffix(URI baseURI, String id, String suffix, String uri) {
         EntryUriSuffix entry = null;
         if (suffix != null && uri != null) {
-            entry = new EntryUriSuffix(baseURI, id, suffix, uri);
+            entry = new EntryUriSuffix(config, baseURI, id, suffix, uri);
             add(entry);
         } else {
             error("Invalid uriSuffix entry (missing uriStartString or uri attribute)");
@@ -180,7 +180,7 @@ public class EntryCatalog extends Entry {
     public EntryDelegateUri addDelegateUri(URI baseURI, String id, String startString, String catalog) {
         EntryDelegateUri entry = null;
         if (startString != null && catalog != null) {
-            entry = new EntryDelegateUri(baseURI, id, startString, catalog);
+            entry = new EntryDelegateUri(config, baseURI, id, startString, catalog);
             add(entry);
         } else {
             error("Invalid delegateURI entry (missing uriStartString or catalog attribute)");
@@ -191,7 +191,7 @@ public class EntryCatalog extends Entry {
     public EntryNextCatalog addNextCatalog(URI baseURI, String id, String catalog) {
         EntryNextCatalog entry = null;
         if (catalog != null) {
-            entry = new EntryNextCatalog(baseURI, id, catalog);
+            entry = new EntryNextCatalog(config, baseURI, id, catalog);
             add(entry);
         } else {
             error("Invalid nextCatalog entry (missing catalog attribute)");
@@ -202,7 +202,7 @@ public class EntryCatalog extends Entry {
     public EntryDoctype addDoctype(URI baseURI, String id, String name, String uri) {
         EntryDoctype entry = null;
         if (name != null && uri != null) {
-            entry = new EntryDoctype(baseURI, id, name, uri);
+            entry = new EntryDoctype(config, baseURI, id, name, uri);
             add(entry);
         } else {
             error("Invalid doctype entry (missing name or uri attribute)");
@@ -213,7 +213,7 @@ public class EntryCatalog extends Entry {
     public EntryDocument addDocument(URI baseURI, String id, String uri) {
         EntryDocument entry = null;
         if (uri != null) {
-            entry = new EntryDocument(baseURI, id, uri);
+            entry = new EntryDocument(config, baseURI, id, uri);
             add(entry);
         } else {
             error("Invalid document entry (missing uri attribute)");
@@ -224,7 +224,7 @@ public class EntryCatalog extends Entry {
     public EntryDtddecl addDtdDecl(URI baseURI, String id, String publicId, String uri) {
         EntryDtddecl entry = null;
         if (publicId != null && uri != null) {
-            entry = new EntryDtddecl(baseURI, id, publicId, uri);
+            entry = new EntryDtddecl(config, baseURI, id, publicId, uri);
             add(entry);
         } else {
             error("Invalid dtddecl entry (missing publicId or uri attribute)");
@@ -235,7 +235,7 @@ public class EntryCatalog extends Entry {
     public EntryEntity addEntity(URI baseURI, String id, String name, String uri) {
         EntryEntity entry = null;
         if (name != null && uri != null) {
-            entry = new EntryEntity(baseURI, id, name, uri);
+            entry = new EntryEntity(config, baseURI, id, name, uri);
             add(entry);
         } else {
             error("Invalid entity entry (missing name or uri attribute)");
@@ -246,7 +246,7 @@ public class EntryCatalog extends Entry {
     public EntryLinktype addLinktype(URI baseURI, String id, String name, String uri) {
         EntryLinktype entry = null;
         if (name != null && uri != null) {
-            entry = new EntryLinktype(baseURI, id, name, uri);
+            entry = new EntryLinktype(config, baseURI, id, name, uri);
             add(entry);
         } else {
             error("Invalid linktype entry (missing name or uri attribute)");
@@ -257,7 +257,7 @@ public class EntryCatalog extends Entry {
     public EntryNotation addNotation(URI baseURI, String id, String name, String uri) {
         EntryNotation entry = null;
         if (name != null && uri != null) {
-            entry = new EntryNotation(baseURI, id, name, uri);
+            entry = new EntryNotation(config, baseURI, id, name, uri);
             add(entry);
         } else {
             error("Invalid notation entry (missing name or uri attribute)");
@@ -268,7 +268,7 @@ public class EntryCatalog extends Entry {
     public EntrySgmldecl addSgmlDecl(URI baseURI, String id, String uri) {
         EntrySgmldecl entry = null;
         if (uri != null) {
-            entry = new EntrySgmldecl(baseURI, id, uri);
+            entry = new EntrySgmldecl(config, baseURI, id, uri);
             add(entry);
         } else {
             error("Invalid sgmldecl entry (uri attribute)");

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryDelegatePublic.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryDelegatePublic.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -9,8 +10,8 @@ public class EntryDelegatePublic extends Entry {
     public final String publicIdStart;
     public final URI catalog;
 
-    public EntryDelegatePublic(URI baseURI, String id, String start, String catalog, boolean prefer) {
-        super(baseURI, id);
+    public EntryDelegatePublic(ResolverConfiguration config, URI baseURI, String id, String start, String catalog, boolean prefer) {
+        super(config, baseURI, id);
         this.publicIdStart = start;
         this.catalog = URIUtils.resolve(baseURI, catalog);
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryDelegateSystem.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryDelegateSystem.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntryDelegateSystem extends Entry {
     public final String systemIdStart;
     public final URI catalog;
 
-    public EntryDelegateSystem(URI baseURI, String id, String start, String catalog) {
-        super(baseURI, id);
+    public EntryDelegateSystem(ResolverConfiguration config, URI baseURI, String id, String start, String catalog) {
+        super(config, baseURI, id);
 
         if (start.startsWith("classpath:/")) {
             // classpath:/path/to/thing is the same as classpath:path/to/thing

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryDelegateUri.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryDelegateUri.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntryDelegateUri extends Entry {
     public final String uriStart;
     public final URI catalog;
 
-    public EntryDelegateUri(URI baseURI, String id, String start, String catalog) {
-        super(baseURI, id);
+    public EntryDelegateUri(ResolverConfiguration config, URI baseURI, String id, String start, String catalog) {
+        super(config, baseURI, id);
 
         if (start.startsWith("classpath:/")) {
             // classpath:/path/to/thing is the same as classpath:path/to/thing

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryDoctype.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryDoctype.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntryDoctype extends Entry {
     public final String name;
     public final URI uri;
 
-    public EntryDoctype(URI baseURI, String id, String name, String uri) {
-        super(baseURI, id);
+    public EntryDoctype(ResolverConfiguration config, URI baseURI, String id, String name, String uri) {
+        super(config, baseURI, id);
         this.name = name;
         this.uri = URIUtils.resolve(baseURI, uri);
     }

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryDocument.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryDocument.java
@@ -1,10 +1,12 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryDocument extends EntryResource {
-    public EntryDocument(URI baseURI, String id, String uri) {
-        super(baseURI, id, uri);
+    public EntryDocument(ResolverConfiguration config, URI baseURI, String id, String uri) {
+        super(config, baseURI, id, uri);
     }
 
     @Override

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryDtddecl.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryDtddecl.java
@@ -1,12 +1,14 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryDtddecl extends EntryResource {
     public final String publicId;
 
-    public EntryDtddecl(URI baseURI, String id, String publicId, String uri) {
-        super(baseURI, id, uri);
+    public EntryDtddecl(ResolverConfiguration config, URI baseURI, String id, String publicId, String uri) {
+        super(config, baseURI, id, uri);
         this.publicId = publicId;
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryEntity.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryEntity.java
@@ -1,12 +1,14 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryEntity extends EntryResource {
     public final String name;
 
-    public EntryEntity(URI baseURI, String id, String name, String uri) {
-        super(baseURI, id, uri);
+    public EntryEntity(ResolverConfiguration config, URI baseURI, String id, String name, String uri) {
+        super(config, baseURI, id, uri);
         this.name = name;
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryGroup.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryGroup.java
@@ -1,13 +1,14 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryGroup extends Entry {
     public final boolean preferPublic;
 
-    public EntryGroup(URI baseURI, String id, boolean prefer) {
-        super(baseURI, id);
-        // FIXME: warn if prefer is neither public nor system
+    public EntryGroup(ResolverConfiguration config, URI baseURI, String id, boolean prefer) {
+        super(config, baseURI, id);
         this.preferPublic = prefer;
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryLinktype.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryLinktype.java
@@ -1,12 +1,14 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryLinktype extends EntryResource {
     public final String name;
 
-    public EntryLinktype(URI baseURI, String id, String name, String uri) {
-        super(baseURI, id, uri);
+    public EntryLinktype(ResolverConfiguration config, URI baseURI, String id, String name, String uri) {
+        super(config, baseURI, id, uri);
         this.name = name;
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryNextCatalog.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryNextCatalog.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -7,8 +8,8 @@ import java.net.URI;
 public class EntryNextCatalog extends Entry {
     public final URI catalog;
 
-    public EntryNextCatalog(URI baseURI, String id, String catalog) {
-        super(baseURI, id);
+    public EntryNextCatalog(ResolverConfiguration config, URI baseURI, String id, String catalog) {
+        super(config, baseURI, id);
         this.catalog = URIUtils.resolve(baseURI, catalog);
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryNotation.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryNotation.java
@@ -1,12 +1,14 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryNotation extends EntryResource {
     public final String name;
 
-    public EntryNotation(URI baseURI, String id, String name, String uri) {
-        super(baseURI, id, uri);
+    public EntryNotation(ResolverConfiguration config, URI baseURI, String id, String name, String uri) {
+        super(config, baseURI, id, uri);
         this.name = name;
     }
 

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryNull.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryNull.java
@@ -1,10 +1,12 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryNull extends Entry {
-    public EntryNull() {
-        super(URI.create("http://xmlresolver.org/irrelevant"), null);
+    public EntryNull(ResolverConfiguration config) {
+        super(config, URI.create("http://xmlresolver.org/irrelevant"), null);
     }
 
     @Override

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryPublic.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryPublic.java
@@ -1,13 +1,15 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryPublic extends EntryResource {
     public final String publicId;
     public final boolean preferPublic;
 
-    public EntryPublic(URI baseURI, String id, String publicId, String uri, boolean prefer) {
-        super(baseURI, id, uri);
+    public EntryPublic(ResolverConfiguration config, URI baseURI, String id, String publicId, String uri, boolean prefer) {
+        super(config, baseURI, id, uri);
         this.publicId = publicId;
         this.preferPublic = prefer;
     }

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryResource.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryResource.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ import java.net.URI;
 public abstract class EntryResource extends Entry {
     public final URI uri;
 
-    public EntryResource(URI baseURI, String id, String uri) {
-        super(baseURI, id);
+    public EntryResource(ResolverConfiguration config, URI baseURI, String id, String uri) {
+        super(config, baseURI, id);
         this.uri = URIUtils.resolve(baseURI, uri);
     }
 }

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryRewriteSystem.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryRewriteSystem.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntryRewriteSystem extends Entry {
     public final String systemIdStart;
     public final URI rewritePrefix;
 
-    public EntryRewriteSystem(URI baseURI, String id, String start, String rewrite) {
-        super(baseURI, id);
+    public EntryRewriteSystem(ResolverConfiguration config, URI baseURI, String id, String start, String rewrite) {
+        super(config, baseURI, id);
 
         if (start.startsWith("classpath:/")) {
             // classpath:/path/to/thing is the same as classpath:path/to/thing

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryRewriteUri.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryRewriteUri.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntryRewriteUri extends Entry {
     public final String uriStart;
     public final URI rewritePrefix;
 
-    public EntryRewriteUri(URI baseURI, String id, String start, String rewrite) {
-        super(baseURI, id);
+    public EntryRewriteUri(ResolverConfiguration config, URI baseURI, String id, String start, String rewrite) {
+        super(config, baseURI, id);
 
         if (start.startsWith("classpath:/")) {
             // classpath:/path/to/thing is the same as classpath:path/to/thing

--- a/src/main/java/org/xmlresolver/catalog/entry/EntrySgmldecl.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntrySgmldecl.java
@@ -1,10 +1,12 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntrySgmldecl extends EntryResource {
-    public EntrySgmldecl(URI baseURI, String id, String uri) {
-        super(baseURI, id, uri);
+    public EntrySgmldecl(ResolverConfiguration config, URI baseURI, String id, String uri) {
+        super(config, baseURI, id, uri);
     }
 
     @Override

--- a/src/main/java/org/xmlresolver/catalog/entry/EntrySystem.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntrySystem.java
@@ -1,12 +1,14 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntrySystem extends EntryResource {
     public final String systemId;
 
-    public EntrySystem(URI baseURI, String id, String systemId, String uri) {
-        super(baseURI, id, uri);
+    public EntrySystem(ResolverConfiguration config, URI baseURI, String id, String systemId, String uri) {
+        super(config, baseURI, id, uri);
 
         if (systemId.startsWith("classpath:/")) {
             // classpath:/path/to/thing is the same as classpath:path/to/thing

--- a/src/main/java/org/xmlresolver/catalog/entry/EntrySystemSuffix.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntrySystemSuffix.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntrySystemSuffix extends Entry {
     public final String systemIdSuffix;
     public final URI uri;
 
-    public EntrySystemSuffix(URI baseURI, String id, String suffix, String uri) {
-        super(baseURI, id);
+    public EntrySystemSuffix(ResolverConfiguration config, URI baseURI, String id, String suffix, String uri) {
+        super(config, baseURI, id);
         this.systemIdSuffix = suffix;
         this.uri = URIUtils.resolve(baseURI, uri);
     }

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryUri.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryUri.java
@@ -1,5 +1,7 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
+
 import java.net.URI;
 
 public class EntryUri extends EntryResource {
@@ -7,8 +9,8 @@ public class EntryUri extends EntryResource {
     public final String nature;
     public final String purpose;
 
-    public EntryUri(URI baseURI, String id, String name, String uri, String nature, String purpose) {
-        super(baseURI, id, uri);
+    public EntryUri(ResolverConfiguration config, URI baseURI, String id, String name, String uri, String nature, String purpose) {
+        super(config, baseURI, id, uri);
 
         if (name.startsWith("classpath:/")) {
             // classpath:/path/to/thing is the same as classpath:path/to/thing

--- a/src/main/java/org/xmlresolver/catalog/entry/EntryUriSuffix.java
+++ b/src/main/java/org/xmlresolver/catalog/entry/EntryUriSuffix.java
@@ -1,5 +1,6 @@
 package org.xmlresolver.catalog.entry;
 
+import org.xmlresolver.ResolverConfiguration;
 import org.xmlresolver.utils.URIUtils;
 
 import java.net.URI;
@@ -8,8 +9,8 @@ public class EntryUriSuffix extends Entry {
     public final String uriSuffix;
     public final URI uri;
 
-    public EntryUriSuffix(URI baseURI, String id, String suffix, String uri) {
-        super(baseURI, id);
+    public EntryUriSuffix(ResolverConfiguration config, URI baseURI, String id, String suffix, String uri) {
+        super(config, baseURI, id);
         this.uriSuffix = suffix;
         this.uri = URIUtils.resolve(baseURI, uri);
     }

--- a/src/main/java/org/xmlresolver/catalog/query/QueryCatalog.java
+++ b/src/main/java/org/xmlresolver/catalog/query/QueryCatalog.java
@@ -1,15 +1,12 @@
 package org.xmlresolver.catalog.query;
 
 import org.xmlresolver.CatalogManager;
-import org.xmlresolver.ResolverLogger;
 import org.xmlresolver.catalog.entry.EntryCatalog;
 
 import java.net.URI;
 import java.util.ArrayList;
 
 public abstract class QueryCatalog extends QueryResult {
-    protected static ResolverLogger logger = new ResolverLogger(QueryCatalog.class);
-
     public QueryCatalog() {
         super();
     }

--- a/src/main/java/org/xmlresolver/logging/DefaultLogger.java
+++ b/src/main/java/org/xmlresolver/logging/DefaultLogger.java
@@ -1,0 +1,75 @@
+package org.xmlresolver.logging;
+
+import org.xmlresolver.ResolverConfiguration;
+import org.xmlresolver.ResolverFeature;
+
+/**
+ * The default logger logs to {@link System#err}.
+ *
+ * <p>The {@link ResolverFeature#DEFAULT_LOGGER_LOG_LEVEL DEFAULT_LOGGER_LOG_LEVEL} feature determines
+ * which messages are logged. The valid levels are "debug", "info", and "warn". An invalid level
+ * is treated as "warn".</p>
+ *
+ * <p>If the level is set to "debug", all messages will be printed. If set to "info", info and warning
+ * messages will be printed. If set to "warn", only warning messages will be printed.</p>
+ */
+public class DefaultLogger extends AbstractLogger {
+    private final int logLevel;
+
+    /**
+     * Initialize the logger.
+     *
+     * <p>The {@link ResolverFeature#DEFAULT_LOGGER_LOG_LEVEL DEFAULT_LOGGER_LOG_LEVEL} is obtained
+     * from the configuration.</p>
+     *
+     * @param config The resolver configuration.
+     */
+    public DefaultLogger(ResolverConfiguration config) {
+        super();
+
+        String level = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+        if ("info".equalsIgnoreCase(level)) {
+            logLevel = AbstractLogger.INFO;
+        } else if ("debug".equalsIgnoreCase(level)) {
+            logLevel = AbstractLogger.DEBUG;
+        } else if ("warn".equalsIgnoreCase(level)) {
+            logLevel = AbstractLogger.WARN;
+        } else {
+            System.err.println("Invalid default logger log level: " + level);
+            logLevel = AbstractLogger.WARN;
+        }
+    }
+
+    /**
+     * Writes an informational message to {@link System#err}.
+     * @param message The message.
+     */
+    @Override
+    public void info(String message) {
+        if (logLevel <= AbstractLogger.INFO) {
+            System.err.println(message);
+        }
+    }
+
+    /**
+     * Writes a debug message to {@link System#err}.
+     * @param message The message.
+     */
+    @Override
+    public void debug(String message) {
+        if (logLevel <= AbstractLogger.DEBUG) {
+            System.err.println(message);
+        }
+    }
+
+    /**
+     * Writes a warning message to {@link System#err}.
+     * @param message The message.
+     */
+    @Override
+    public void warn(String message) {
+        if (logLevel <= AbstractLogger.WARN) {
+            System.err.println(message);
+        }
+    }
+}

--- a/src/main/java/org/xmlresolver/logging/ResolverLogger.java
+++ b/src/main/java/org/xmlresolver/logging/ResolverLogger.java
@@ -1,0 +1,75 @@
+package org.xmlresolver.logging;
+
+import java.util.Formatter;
+
+/**
+ * The resolver logger interface defines the features of a logging class for the resolver.
+ *
+ * <p>The resolver logs messages by calling {@link ResolverLogger#log}. The categories
+ * are defined as constants in this class. Different log levels can be specified for
+ * the different classes. Which levels result in output, and where that output goes
+ * depends on the back end. {@link DefaultLogger} sends messages to standard error.
+ * {@link SystemLogger} connects to a logging backend. Configuring the logging backend
+ * is performed at runtime according to the mechanisms defined for that backend. That
+ * level of configuration is outside the scope of the resolver logger.</p>
+ *
+ * <p>The log levels are "debug", "info", and "warn". Exactly what levels make sense
+ * and how they're mapped to different backends is a little arbitrary. Debug level
+ * messages describe in detail how a request is processed. Info level messages are
+ * summaries of processing, likely one or two per request. Warning messages indicate
+ * that an error has been detected. The resolver tries to be very forgiving of errors,
+ * ignoring most conditions rather than throwing exceptions.</p>
+ */
+public interface ResolverLogger {
+    /**
+     * Returns the log level, "debug", "info", or worn", associated with a category.
+     * @param cat The category.
+     * @return The level. If no level has been configured for that category, the default is "debug".
+     */
+    String getCategory(String cat);
+
+    /**
+     * Set the log level for a category. After this call, messages in the specified category
+     * will be logged at the specified level. Valid levels are "debug", "info", and "warn".
+     * An invalid level is treated as "debug".
+     * @param cat The category.
+     * @param level The level.
+     */
+    void setCategory(String cat, String level);
+
+    /**
+     * Log a message.
+     *
+     * <p>The category is used to determine what level of logging is
+     * expected for this message. The message is then formatted with its parameters
+     * and logged.</p>
+     *
+     * <p>The actual logging is done by the {@link #warn}, {@link #info}, and {@link #debug} methods,
+     * but they are never called directly by the resolver.</p>
+     *
+     * <p>The message and its parameters are formatted with {@link Formatter}.</p>
+     *
+     * @param cat The category.
+     * @param message The message.
+     * @param params The message parameters.
+     */
+    void log(String cat, String message, Object... params);
+
+    /**
+     * Process a warning message.
+     * @param message The message.
+     */
+    void warn(String message);
+
+    /**
+     * Process an informational message.
+     * @param message The message.
+     */
+    void info(String message);
+
+    /**
+     * Process a debug or "trace" message.
+     * @param message The message.
+     */
+    void debug(String message);
+}

--- a/src/main/java/org/xmlresolver/logging/SystemLogger.java
+++ b/src/main/java/org/xmlresolver/logging/SystemLogger.java
@@ -1,0 +1,94 @@
+package org.xmlresolver.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xmlresolver.Resolver;
+import org.xmlresolver.ResolverConfiguration;
+import org.xmlresolver.ResolverFeature;
+
+/**
+ * The system logger interfaces to a logging backend via a logging backend.
+ *
+ * <p>This class supports either configuration with {@link org.slf4j.Logger org.slf4j.Logger} or
+ * configuration directly with a {@link java.util.logging.Logger java.util.logging.Logger}.</p>
+ *
+ * <p>This logger makes it easy to configure the resolver to log through a standard
+ * logging framework, as might be present on a Java application server. By default
+ * the logger uses the {@link org.slf4j.LoggerFactory org.slf4j.LoggerFactory} to create a logger. This logger
+ * can be supported at runtime by a wide variety of concrete backend classes. For details
+ * on how SLF4J finds a logging backend, see their documentation.</p>
+ *
+ * <p>Alternatively, if you instantiate the <code>SystemLogger</code> with a
+ * {@link java.util.logging.Logger java.util.logging.Logger} directly, it will use that.</p>
+ *
+ * <p>When instantiated with the {@link org.xmlresolver.ResolverFeature#RESOLVER_LOGGER_CLASS},
+ * the default logging framework is always used. To use the {@link java.util.logging.Logger}
+ * alternative, you must instantiate the logger yourself and set the
+ * {@link org.xmlresolver.ResolverFeature#RESOLVER_LOGGER} feature yourself.</p>
+ */
+public class SystemLogger extends AbstractLogger {
+    private final Logger logger;
+    private final java.util.logging.Logger jlogger;
+
+    /**
+     * Initialize the logger using the default backend.
+     *
+     * <p>This class doesn't actually use the provided resolver configuration, but it's
+     * necessary to support the way loggers are instantiated by the configuration.</p>
+     *
+     * @param config The resolver configuration.
+     */
+    public SystemLogger(ResolverConfiguration config) {
+        logger = LoggerFactory.getLogger(Resolver.class);
+        jlogger = null;
+    }
+
+    /**
+     * Initialize the logger using an explicit {@link java.util.logging.Logger}.
+     *
+     * @param log The logger.
+     */
+    public SystemLogger(java.util.logging.Logger log) {
+        logger = null;
+        jlogger = log;
+    }
+
+    /**
+     * Process a warning message with the underlying logging framework.
+     * @param message The message.
+     */
+    @Override
+    public void warn(String message) {
+        if (jlogger != null) {
+            jlogger.warning(message);
+        } else {
+            logger.warn(message);
+        }
+    }
+
+    /**
+     * Process an informational message with the underlying logging framework.
+     * @param message The message.
+     */
+    @Override
+    public void info(String message) {
+        if (jlogger != null) {
+            jlogger.info(message);
+        } else {
+            logger.info(message);
+        }
+    }
+
+    /**
+     * Process a debug message with the underlying logging framework.
+     * @param message The message.
+     */
+    @Override
+    public void debug(String message) {
+        if (jlogger != null) {
+            jlogger.fine(message);
+        } else {
+            logger.debug(message);
+        }
+    }
+}

--- a/src/main/java/org/xmlresolver/logging/package-info.java
+++ b/src/main/java/org/xmlresolver/logging/package-info.java
@@ -1,0 +1,15 @@
+/** Resolver logging.
+ *
+ * <p>The resolver logs configuration changes, resolution attempts, caching, and
+ * a variety of other operations. Each of these log messages is sent to the
+ * {@link ResolverLogger} in the configuration.</p>
+ *
+ * <p>The {@link DefaultLogger} sends messages to <code>System.err</code>. The
+ * {@link SystemLogger} uses a logging backend. By default, it configures itself
+ * to use any one of the logging backends supported by {@link org.slf4j.LoggerFactory}.
+ * Alternatively, it may be configured directly with a
+ * {@link java.util.logging.Logger}.</p>
+ *
+ */
+
+ package org.xmlresolver.logging;

--- a/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
+++ b/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
@@ -16,8 +16,9 @@ import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLFilterImpl;
 import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.Resolver;
-import org.xmlresolver.ResolverLogger;
 import org.xmlresolver.XMLResolverConfiguration;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
 import org.xmlresolver.utils.URIUtils;
 
 import java.io.IOException;
@@ -35,7 +36,7 @@ import java.net.URISyntaxException;
  * @author ndw
  */
 public class ResolvingXMLFilter extends XMLFilterImpl {
-    protected static ResolverLogger logger = new ResolverLogger(ResolvingXMLFilter.class);
+    protected final ResolverLogger logger;
 
     /** Are oasis-xml-catalog PIs allowed by this catalog? */
     private boolean allowXMLCatalogPI = true;
@@ -56,6 +57,7 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
         }
         resolver = staticResolver;
         allowXMLCatalogPI = resolver.getConfiguration().getFeature(ResolverFeature.ALLOW_CATALOG_PI);
+        logger = resolver.getConfiguration().getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** Construct an XML filter with the specified resolver.
@@ -66,6 +68,7 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
         super();
         this.resolver = resolver;
         allowXMLCatalogPI = resolver.getConfiguration().getFeature(ResolverFeature.ALLOW_CATALOG_PI);
+        logger = resolver.getConfiguration().getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /** Construct an XML filter with the specified parent and resolver.
@@ -76,6 +79,7 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
     public ResolvingXMLFilter(XMLReader parent, Resolver resolver) {
         super(parent);
         this.resolver = resolver;
+        logger = resolver.getConfiguration().getFeature(ResolverFeature.RESOLVER_LOGGER);
     }
 
     /**
@@ -212,7 +216,7 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
 
                             resolver.getConfiguration().addCatalog(catalog.toString());
                         } catch (URISyntaxException mue) {
-                            logger.log(ResolverLogger.WARNING, "URI syntax exception resolving PI catalog: %s", data);
+                            logger.log(AbstractLogger.WARNING, "URI syntax exception resolving PI catalog: %s", data);
                         }
                     }
                 }

--- a/src/main/java/org/xmlresolver/utils/URIUtils.java
+++ b/src/main/java/org/xmlresolver/utils/URIUtils.java
@@ -9,8 +9,6 @@
 
 package org.xmlresolver.utils;
 
-import org.xmlresolver.ResolverLogger;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -20,8 +18,6 @@ import java.nio.charset.StandardCharsets;
  * @author ndw
  */
 public abstract class URIUtils {
-    protected static ResolverLogger logger = new ResolverLogger(URIUtils.class);
-
     /**
      * Creates a URI for the users current working directory.
      *
@@ -39,7 +35,6 @@ public abstract class URIUtils {
         try {
             return URIUtils.newURI(dir);
         } catch (URISyntaxException ex) {
-            logger.log(ResolverLogger.WARNING, "Failed to create URI from user.dir: %s", dir);
             return URI.create("file:///"); // ¯\_(ツ)_/¯
         }
     }

--- a/src/test/java/org/xmlresolver/CatalogResolverTest.java
+++ b/src/test/java/org/xmlresolver/CatalogResolverTest.java
@@ -22,7 +22,7 @@ public class CatalogResolverTest {
         resolver = new Resolver(config);
 
         // Make sure the Docker container is running where we expect.
-        ResourceConnection conn = new ResourceConnection("http://localhost:8222/docs/sample/sample.dtd", true);
+        ResourceConnection conn = new ResourceConnection(config, "http://localhost:8222/docs/sample/sample.dtd", true);
         Assert.assertEquals(200, conn.getStatusCode());
     }
 

--- a/src/test/java/org/xmlresolver/CatalogSpacesTest.java
+++ b/src/test/java/org/xmlresolver/CatalogSpacesTest.java
@@ -26,7 +26,7 @@ public class CatalogSpacesTest {
         resolver = new Resolver(config);
 
         // Make sure the Docker container is running where we expect.
-        ResourceConnection conn = new ResourceConnection("http://localhost:8222/docs/sample/sample.dtd", true);
+        ResourceConnection conn = new ResourceConnection(config, "http://localhost:8222/docs/sample/sample.dtd", true);
         Assert.assertEquals(200, conn.getStatusCode());
     }
 

--- a/src/test/java/org/xmlresolver/LoggerTest.java
+++ b/src/test/java/org/xmlresolver/LoggerTest.java
@@ -1,0 +1,44 @@
+package org.xmlresolver;
+
+import org.junit.Test;
+import org.xmlresolver.logging.DefaultLogger;
+import org.xmlresolver.logging.ResolverLogger;
+import org.xmlresolver.logging.SystemLogger;
+
+import java.util.logging.Logger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LoggerTest {
+    @Test
+    public void defaultLogger() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(DefaultLogger.class, logger.getClass());
+    }
+
+    @Test
+    public void systemLogger() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        config.setFeature(ResolverFeature.RESOLVER_LOGGER_CLASS, "org.xmlresolver.logging.SystemLogger");
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(SystemLogger.class, logger.getClass());
+    }
+
+    @Test
+    public void javaSystemLogger() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        java.util.logging.Logger jlogger = Logger.getLogger("testing");
+        config.setFeature(ResolverFeature.RESOLVER_LOGGER, new SystemLogger(jlogger));
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(SystemLogger.class, logger.getClass());
+        logger.log("WARN", "This is a test");
+    }
+
+
+
+}

--- a/src/test/java/org/xmlresolver/RddlTest.java
+++ b/src/test/java/org/xmlresolver/RddlTest.java
@@ -29,7 +29,7 @@ public class RddlTest extends CacheManager {
         resolver = new CatalogResolver(config);
 
         // Make sure the Docker container is running where we expect.
-        ResourceConnection conn = new ResourceConnection("http://localhost:8222/docs/sample/sample.dtd", true);
+        ResourceConnection conn = new ResourceConnection(config, "http://localhost:8222/docs/sample/sample.dtd", true);
         assertEquals(200, conn.getStatusCode());
     }
 

--- a/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
+++ b/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
@@ -37,7 +37,7 @@ public class ResolverTestLocalhost extends CacheManager {
         config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
 
         // Make sure the Docker container is running where we expect.
-        ResourceConnection conn = new ResourceConnection("http://localhost:8222/docs/sample/sample.dtd", true);
+        ResourceConnection conn = new ResourceConnection(config, "http://localhost:8222/docs/sample/sample.dtd", true);
         assertEquals(200, conn.getStatusCode());
     }
 


### PR DESCRIPTION
This PR reworks logging so that there's a default logger that just writes to stderr. It's possible to instantiate a different logger that will write to a logging backend. I think this is an improvement. Mostly.

Fix #75.
