### PR TITLE
Improve DefaultLogger; don't cache data URIs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=4.0.0
+resolverVersion=4.1.0
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/logging/AbstractLogger.java
+++ b/src/main/java/org/xmlresolver/logging/AbstractLogger.java
@@ -26,6 +26,7 @@ public abstract class AbstractLogger implements ResolverLogger {
     protected static final int DEBUG = 1;
     protected static final int INFO = 2;
     protected static final int WARN = 3;
+    protected static final int NONE = 4;
 
     protected final HashMap<String, Integer> categories = new HashMap<>();
     protected String catalogLogging = null;
@@ -36,16 +37,24 @@ public abstract class AbstractLogger implements ResolverLogger {
     }
 
     /**
-     * Returns the log level, "debug", "info", or worn", associated with a category.
+     * Returns the log level, "debug", "info", worn", or "none" associated with a category.
      * @param cat The category.
      * @return The level. If no level has been configured for that category, the default is "debug".
      */
     public String getCategory(String cat) {
         if (categories.containsKey(cat)) {
-            if (INFO == categories.get(cat)) {
-                return "info";
-            } else if (WARN == categories.get(cat)) {
-                return "warn";
+            switch (categories.get(cat)) {
+                case INFO:
+                    return "info";
+                case WARN:
+                    return "warn";
+                case NONE:
+                    return "none";
+                case DEBUG:
+                    return "debug";
+                default:
+                    // this "can't" happen
+                    break;
             }
         }
         return "debug";
@@ -59,15 +68,23 @@ public abstract class AbstractLogger implements ResolverLogger {
      * @param level The level.
      */
     public void setCategory(String cat, String level) {
-        if ("info".equals(level)) {
-            categories.put(cat, INFO);
-        } else if ("warn".equals(level)) {
-            categories.put(cat, WARN);
-        } else {
-            categories.put(cat, DEBUG);
-            if (!"debug".equals(level)) {
+        switch (level) {
+            case "info":
+                categories.put(cat, INFO);
+                break;
+            case "warn":
+                categories.put(cat, WARN);
+                break;
+            case "debug":
+                categories.put(cat, DEBUG);
+                break;
+            case "none":
+                categories.put(cat, NONE);
+                break;
+            default:
+                categories.put(cat, DEBUG);
                 info("Incorrect logging level specified: " + level + " treated as 'debug'");
-            }
+                break;
         }
     }
 
@@ -105,6 +122,8 @@ public abstract class AbstractLogger implements ResolverLogger {
         Integer level = categories.getOrDefault(cat, deflevel);
 
         switch (level) {
+            case NONE:
+                break;
             case WARN:
                 warn(logMessage(cat, message, params));
                 break;

--- a/src/main/java/org/xmlresolver/logging/DefaultLogger.java
+++ b/src/main/java/org/xmlresolver/logging/DefaultLogger.java
@@ -7,11 +7,12 @@ import org.xmlresolver.ResolverFeature;
  * The default logger logs to {@link System#err}.
  *
  * <p>By default, the {@link ResolverFeature#DEFAULT_LOGGER_LOG_LEVEL DEFAULT_LOGGER_LOG_LEVEL} feature determines
- * which messages are logged. The valid levels are "debug", "info", and "warn". An invalid level
+ * which messages are logged. The valid levels are "debug", "info", "warn", and "none". An invalid level
  * is treated as "warn".</p>
  *
  * <p>If the level is set to "debug", all messages will be printed. If set to "info", info and warning
- * messages will be printed. If set to "warn", only warning messages will be printed.</p>
+ * messages will be printed. If set to "warn", only warning messages will be printed. If set to "none",
+ * no messages are printed.</p>
  *
  * <p>If the configuration's <code>DEFAULT_LOGGER_LOG_LEVEL</code> is changed, that change will be
  * detected by the logger and it will use that level going forward. The value can also be changed
@@ -52,7 +53,10 @@ public class DefaultLogger extends AbstractLogger {
                 return "debug";
             case AbstractLogger.WARN:
                 return "warn";
+            case AbstractLogger.NONE:
+                return "none";
             default:
+                // This "can't" happen.
                 return "unknown";
         }
     }
@@ -64,16 +68,23 @@ public class DefaultLogger extends AbstractLogger {
     public void setLogLevel(String level) {
         currentLoggingLevel = level;
 
-        if ("info".equalsIgnoreCase(level)) {
-            logLevel = AbstractLogger.INFO;
-        } else if ("debug".equalsIgnoreCase(level)) {
-            logLevel = AbstractLogger.DEBUG;
-        } else if ("warn".equalsIgnoreCase(level)) {
-            logLevel = AbstractLogger.WARN;
-        } else {
-            System.err.println("Invalid default logger log level: " + level);
-            logLevel = AbstractLogger.WARN;
-            currentLoggingLevel = "warn";
+        switch (level) {
+            case "info":
+                logLevel = AbstractLogger.INFO;
+                break;
+            case "debug":
+                logLevel = AbstractLogger.DEBUG;
+                break;
+            case "warn":
+                logLevel = AbstractLogger.WARN;
+                break;
+            case "none":
+                logLevel = AbstractLogger.NONE;
+                break;
+            default:
+                System.err.println("Invalid default logger log level: " + level);
+                logLevel = AbstractLogger.WARN;
+                currentLoggingLevel = "warn";
         }
     }
 

--- a/src/main/java/org/xmlresolver/logging/DefaultLogger.java
+++ b/src/main/java/org/xmlresolver/logging/DefaultLogger.java
@@ -6,15 +6,23 @@ import org.xmlresolver.ResolverFeature;
 /**
  * The default logger logs to {@link System#err}.
  *
- * <p>The {@link ResolverFeature#DEFAULT_LOGGER_LOG_LEVEL DEFAULT_LOGGER_LOG_LEVEL} feature determines
+ * <p>By default, the {@link ResolverFeature#DEFAULT_LOGGER_LOG_LEVEL DEFAULT_LOGGER_LOG_LEVEL} feature determines
  * which messages are logged. The valid levels are "debug", "info", and "warn". An invalid level
  * is treated as "warn".</p>
  *
  * <p>If the level is set to "debug", all messages will be printed. If set to "info", info and warning
  * messages will be printed. If set to "warn", only warning messages will be printed.</p>
+ *
+ * <p>If the configuration's <code>DEFAULT_LOGGER_LOG_LEVEL</code> is changed, that change will be
+ * detected by the logger and it will use that level going forward. The value can also be changed
+ * directly by calling {@link #setLogLevel}. That level will remain in effect as long as the configuration
+ * default does not change.
  */
 public class DefaultLogger extends AbstractLogger {
-    private final int logLevel;
+    private final ResolverConfiguration config;
+    private int logLevel;
+    private String defaultLoggerLevel;
+    private String currentLoggingLevel;
 
     /**
      * Initialize the logger.
@@ -26,8 +34,36 @@ public class DefaultLogger extends AbstractLogger {
      */
     public DefaultLogger(ResolverConfiguration config) {
         super();
+        this.config = config;
+        setLogLevel(config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL));
+        defaultLoggerLevel = currentLoggingLevel;
+    }
 
-        String level = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+    /**
+     * Get the current logging level.
+     * @return the current logging level
+     */
+    public String getLogLevel() {
+        checkLoggingLevel();
+        switch (logLevel) {
+            case AbstractLogger.INFO:
+                return "info";
+            case AbstractLogger.DEBUG:
+                return "debug";
+            case AbstractLogger.WARN:
+                return "warn";
+            default:
+                return "unknown";
+        }
+    }
+
+    /**
+     * Set the current logging level.
+     * @param level The logging level.
+     */
+    public void setLogLevel(String level) {
+        currentLoggingLevel = level;
+
         if ("info".equalsIgnoreCase(level)) {
             logLevel = AbstractLogger.INFO;
         } else if ("debug".equalsIgnoreCase(level)) {
@@ -37,6 +73,16 @@ public class DefaultLogger extends AbstractLogger {
         } else {
             System.err.println("Invalid default logger log level: " + level);
             logLevel = AbstractLogger.WARN;
+            currentLoggingLevel = "warn";
+        }
+    }
+
+    private void checkLoggingLevel() {
+        // Blech
+        String currentLevel = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+        if (currentLevel != null && !currentLevel.equals(defaultLoggerLevel)) {
+            setLogLevel(currentLevel);
+            defaultLoggerLevel = currentLoggingLevel;
         }
     }
 
@@ -46,6 +92,7 @@ public class DefaultLogger extends AbstractLogger {
      */
     @Override
     public void info(String message) {
+        checkLoggingLevel();
         if (logLevel <= AbstractLogger.INFO) {
             System.err.println(message);
         }
@@ -57,6 +104,7 @@ public class DefaultLogger extends AbstractLogger {
      */
     @Override
     public void debug(String message) {
+        checkLoggingLevel();
         if (logLevel <= AbstractLogger.DEBUG) {
             System.err.println(message);
         }
@@ -68,6 +116,7 @@ public class DefaultLogger extends AbstractLogger {
      */
     @Override
     public void warn(String message) {
+        checkLoggingLevel();
         if (logLevel <= AbstractLogger.WARN) {
             System.err.println(message);
         }

--- a/src/test/java/org/xmlresolver/LoggerTest.java
+++ b/src/test/java/org/xmlresolver/LoggerTest.java
@@ -58,6 +58,52 @@ public class LoggerTest {
     }
 
     @Test
+    public void changeLoggingLevel() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(DefaultLogger.class, logger.getClass());
+        DefaultLogger deflog = (DefaultLogger) logger;
+        String orig = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+
+        deflog.setLogLevel("info");
+        assertEquals("info", deflog.getLogLevel());
+        deflog.setLogLevel("warn");
+        assertEquals("warn", deflog.getLogLevel());
+        deflog.setLogLevel("debug");
+        assertEquals("debug", deflog.getLogLevel());
+        deflog.setLogLevel("none");
+        assertEquals("none", deflog.getLogLevel());
+        deflog.setLogLevel("spoon");
+        assertEquals("warn", deflog.getLogLevel());
+
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, orig);
+    }
+
+    @Test
+    public void changeDefaultLoggingLevel() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(DefaultLogger.class, logger.getClass());
+        DefaultLogger deflog = (DefaultLogger) logger;
+        String orig = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "info");
+        assertEquals("info", deflog.getLogLevel());
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "warn");
+        assertEquals("warn", deflog.getLogLevel());
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "debug");
+        assertEquals("debug", deflog.getLogLevel());
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "none");
+        assertEquals("none", deflog.getLogLevel());
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "spoon");
+        assertEquals("warn", deflog.getLogLevel());
+
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, orig);
+    }
+
+    @Test
     public void systemLogger() {
         XMLResolverConfiguration config = new XMLResolverConfiguration();
         config.setFeature(ResolverFeature.RESOLVER_LOGGER_CLASS, "org.xmlresolver.logging.SystemLogger");

--- a/src/test/java/org/xmlresolver/LoggerTest.java
+++ b/src/test/java/org/xmlresolver/LoggerTest.java
@@ -20,6 +20,44 @@ public class LoggerTest {
     }
 
     @Test
+    public void changeConfigurationDefaultLoggingLevel() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(DefaultLogger.class, logger.getClass());
+        DefaultLogger deflog = (DefaultLogger) logger;
+        String orig = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "info");
+        assertEquals("info", deflog.getLogLevel());
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "warn");
+        assertEquals("warn", deflog.getLogLevel());
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, orig);
+    }
+
+    @Test
+    public void changeDefaultLoggerLoggingLevel() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        ResolverLogger logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        assertNotNull(logger);
+        assertEquals(DefaultLogger.class, logger.getClass());
+        DefaultLogger deflog = (DefaultLogger) logger;
+        String orig = config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL);
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "info");
+        deflog.setLogLevel("warn");
+        assertEquals("warn", deflog.getLogLevel());
+        assertEquals("info", config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL));
+
+        deflog.setLogLevel("debug");
+        assertEquals("debug", deflog.getLogLevel());
+        assertEquals("info", config.getFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL));
+
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "warn");
+        assertEquals("warn", deflog.getLogLevel());
+
+        config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, orig);
+    }
+
+    @Test
     public void systemLogger() {
         XMLResolverConfiguration config = new XMLResolverConfiguration();
         config.setFeature(ResolverFeature.RESOLVER_LOGGER_CLASS, "org.xmlresolver.logging.SystemLogger");


### PR DESCRIPTION
Fix #80. Fix #81.

This PR contains two fixes. (It probably should have been two PRs, but ...)

1. The `DefaultLogger` is improved so that it is sensitive to changes in the configuration. (This means that if you change the default logging level with the appropriate feature, that will take effect on the next log message.)
2. I added an explicit "none" logging level to disable logging.
3. I reworked the code so that no attempt is made to cache `data:` URIs.

