### PR TITLE
added Automatic-Module-Name to manifests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ jar {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver"
     attributes "Implementation-Version": resolverVersion
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver"
   }
 }
 
@@ -190,6 +191,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver API documentation"
     attributes "Implementation-Version": resolverVersion
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver-javadoc"
   }
 }
 assemble.dependsOn javadocJar
@@ -203,6 +205,7 @@ task sourcesJar(type: Jar, dependsOn: ["generateBuildConfig"]) {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver sources"
     attributes "Implementation-Version": resolverVersion
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver-sources"
   }
 }
 assemble.dependsOn sourcesJar
@@ -216,6 +219,7 @@ task dataJar(type: Jar, dependsOn: ["copyData"]) {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver data"
     attributes "Implementation-Version": resolverVersion
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver-data"
   }
 }
 assemble.dependsOn dataJar


### PR DESCRIPTION
When using newer versions of xmlresolver with the java 9+ module system I encounter the following problem:

```bash
java.lang.module.FindException: Two versions of module xmlresolver found in /mnt/home/tpasch/scm/aanno/db-toolchain/db-toolchain-1.0.0-SNAPSHOT/lib (xmlresolver-4.1.2-data.jar and xmlresolver-4.1.2.jar)
```

This is because of (a) xmlresolver is not module-aware and (b) the jar names results in the same module name for both jars.

The problem is easily fixable by providing a `Automatic-Module-Name` entry in the jar manifests.