### PR TITLE
New tests

### DIFF
--- a/src/test/java/org/xmlresolver/ClasspathTest.java
+++ b/src/test/java/org/xmlresolver/ClasspathTest.java
@@ -8,10 +8,12 @@
 package org.xmlresolver;
 
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import org.xmlresolver.tools.ResolvingXMLReader;
+import org.xmlresolver.utils.URIUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -43,6 +45,18 @@ public class ClasspathTest {
         resolver = new Resolver(config);
         catresolver = resolver.getCatalogResolver();
     }
+
+    @Test
+    public void testResolveUri() {
+        try {
+            URI baseURI = new URI("classpath:/my/class/path/");
+            URI resolved = URIUtils.resolve(baseURI, "my-file.xml");
+            Assert.assertEquals("classpath:my/class/path/my-file.xml", resolved.toString());
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
 
     @Test
     public void testLookup() {

--- a/src/test/java/org/xmlresolver/DataCheckTest.java
+++ b/src/test/java/org/xmlresolver/DataCheckTest.java
@@ -1,0 +1,51 @@
+package org.xmlresolver;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.Collections;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class DataCheckTest {
+    public static XMLResolverConfiguration config = null;
+    public static CatalogManager manager = null;
+
+    @Before
+    public void setup() {
+        String catalog = "classpath:org/xmlresolver/data/catalog.xml";
+        config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
+        config.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList(catalog));
+        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+        config.setFeature(ResolverFeature.CACHE, null);
+        config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
+        manager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
+    }
+
+    @Test
+    public void lookupCheckUri() {
+        URI result = manager.lookupURI("https://xmlresolver.org/data/resolver/succeeded/test/check.xml");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void lookupCheckUriFail() {
+        XMLResolverConfiguration localConfig = null;
+        CatalogManager localManager = null;
+
+        String catalog = "src/test/resources/catalog.xml";
+        localConfig = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
+        localConfig.setFeature(ResolverFeature.CLASSPATH_CATALOGS, false);
+        localConfig.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList(catalog));
+        localConfig.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+        localConfig.setFeature(ResolverFeature.CACHE, null);
+        localConfig.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
+        localManager = localConfig.getFeature(ResolverFeature.CATALOG_MANAGER);
+
+        URI result = localManager.lookupURI("https://xmlresolver.org/data/resolver/succeeded/test/check.xml");
+        assertNull(result);
+    }
+
+}

--- a/src/test/java/org/xmlresolver/NotACatalogTest.java
+++ b/src/test/java/org/xmlresolver/NotACatalogTest.java
@@ -1,4 +1,4 @@
-package org.xmlresolver.tools;
+package org.xmlresolver;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -10,6 +10,7 @@ import org.xmlresolver.XMLResolverConfiguration;
 import org.xmlresolver.sources.ResolverInputSource;
 import org.xmlresolver.utils.URIUtils;
 
+import javax.xml.transform.Source;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -18,23 +19,33 @@ import static org.junit.Assert.*;
 
 public class NotACatalogTest {
     public static final String catalog1 = "src/test/resources/notcatalog.xml";
-    XMLResolverConfiguration config = null;
-    Resolver resolver = null;
-
-    @Before
-    public void setup() {
-        config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog1));
-        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
-        resolver = new Resolver(config);
-    }
+    public static final String catalog2 = "src/test/resources/notcatalog2.xml";
 
     @Test
     public void lookupSystem() {
         try {
+            XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog1));;
+            Resolver resolver = new Resolver(config);
+            config.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+
             // Test for https://github.com/xmlresolver/xmlresolver/issues/59
             // It doesn't matter what we look up; the catalog isn't an XML catalog.
             // But it should return null, not throw an NPE.
             InputSource source = resolver.resolveEntity(null, "https://example.com/sample/1.0/sample.dtd");
+            assertNull(source);
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    @Test
+    public void lookupSystem2() {
+        try {
+            XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog2));;
+            Resolver resolver = new Resolver(config);
+            config.setFeature(ResolverFeature.URI_FOR_SYSTEM, true);
+
+            Source source = resolver.resolve("test.xml", null);
             assertNull(source);
         } catch (Exception ex) {
             fail();

--- a/src/test/java/org/xmlresolver/ResolvingXMLReaderTest.java
+++ b/src/test/java/org/xmlresolver/ResolvingXMLReaderTest.java
@@ -5,13 +5,14 @@
  * Created on January 11, 2007, 9:57 AM
  */
 
-package org.xmlresolver.tools;
+package org.xmlresolver;
 
 import org.junit.Test;
 import org.xml.sax.SAXException;
 import org.xmlresolver.Resolver;
 import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.XMLResolverConfiguration;
+import org.xmlresolver.tools.ResolvingXMLReader;
 
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;

--- a/src/test/resources/notcatalog2.xml
+++ b/src/test/resources/notcatalog2.xml
@@ -1,0 +1,30 @@
+<test-catalog xmlns="https://github.com/cmsmcq/ixml-tests"
+	      release-date="2021-12-16"
+	      name="Amsterdam Test Suite 1">
+
+  <description>
+    <p>Top-level catalog for tests provided by
+    Steven Pemberton in December 2021.</p>
+    <p>There are two sub-groups, one general
+    and one focused on syntax issues.</p>
+  </description>
+
+  <!--* The three syntaxtests catalogs use the
+      * same test cases but test them in slightly
+      * different ways.  You may want all three,
+      * or only one or two, depending on the processor
+      * you are testing.
+      *-->
+  <test-set-ref href="syntax/catalog-as-grammar-tests.xml"/>
+  <test-set-ref href="syntax/catalog-as-instance-tests-ixml.xml"/>
+  <test-set-ref href="syntax/catalog-as-instance-tests-xml.xml"/>
+
+  <!--* Norm reworked the tests-SP-MSM test directory
+      * into a set of separate directories with individual
+      * catalogs
+      *-->
+  <test-set-ref href="ambiguous/test-catalog.xml"/>
+  <test-set-ref href="correct/test-catalog.xml"/>
+  <test-set-ref href="ixml/test-catalog.xml"/>
+  <test-set-ref href="parse/test-catalog.xml"/>
+</test-catalog>


### PR DESCRIPTION
I reworked the tests for "not a catalog" while trying to debug an issue that turned out to be user error. (I was the user, to be fair.)

I also added a test that attempts to resolve `https://xmlresolver.org/data/resolver/succeeded/test/check.xml`. This is expected to succeed only if the XML Resolver Data  is on the classpath.