### PR TITLE
Add SAXPARSERFACTORY_CLASS and XMLREADER_SUPPLIER features

### DIFF
--- a/src/main/java/org/xmlresolver/cache/ResourceCache.java
+++ b/src/main/java/org/xmlresolver/cache/ResourceCache.java
@@ -3,6 +3,7 @@ package org.xmlresolver.cache;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 import org.xmlresolver.*;
 import org.xmlresolver.catalog.entry.Entry;
@@ -194,13 +195,10 @@ public class ResourceCache extends CatalogManager {
         File control = new File(cacheDir, "control.xml");
         if (control.exists()) {
             try {
-                SAXParserFactory spf = SAXParserFactory.newInstance();
-                spf.setNamespaceAware(true);
-                spf.setValidating(false);
-                spf.setXIncludeAware(false);
-                SAXParser parser = spf.newSAXParser();
+                XMLReader reader = config.getFeature(ResolverFeature.XMLREADER_SUPPLIER).get();
+                reader.setContentHandler(new CacheHandler(deleteWait, cacheSize, cacheSpace, maxAge));
                 InputSource source = new InputSource(control.getAbsolutePath());
-                parser.parse(source, new CacheHandler(deleteWait, cacheSize, cacheSpace, maxAge));
+                reader.parse(source);
                 parsed = true;
 
                 // Caching file and classpath URIs is going to be confusing.
@@ -212,7 +210,7 @@ public class ResourceCache extends CatalogManager {
                         cacheInfo.add(new CacheInfo(pattern, false));
                     }
                 }
-            } catch (ParserConfigurationException | SAXException | IOException ex) {
+            } catch (SAXException | IOException ex) {
                 logger.log(AbstractLogger.ERROR, "Failed to parse cache control file: %s", ex.getMessage());
             }
         } else {

--- a/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
+++ b/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
@@ -43,8 +43,8 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
 
     /** Are we in the prolog? Is an oasis-xml-catalog PI valid now? */
     private boolean processXMLCatalogPI = false;
-    private static Resolver staticResolver = null;
-    private Resolver resolver = null;
+    protected static Resolver staticResolver = null;
+    protected Resolver resolver = null;
     
     /** The base URI of the input document, if known. */
     private URI baseURI = null;

--- a/src/test/java/org/xmlresolver/MySAXParserFactory.java
+++ b/src/test/java/org/xmlresolver/MySAXParserFactory.java
@@ -1,0 +1,34 @@
+package org.xmlresolver;
+
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+public class MySAXParserFactory extends SAXParserFactory {
+    private final SAXParserFactory factory;
+    public static int parserCount = 0;
+
+    public MySAXParserFactory() {
+        factory = SAXParserFactory.newInstance();
+    }
+
+    @Override
+    public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+        parserCount++;
+        return factory.newSAXParser();
+    }
+
+    @Override
+    public void setFeature(String name, boolean value) throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+        factory.setFeature(name, value);
+    }
+
+    @Override
+    public boolean getFeature(String name) throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+        return factory.getFeature(name);
+    }
+}

--- a/src/test/java/org/xmlresolver/MyXMLReaderSupplier.java
+++ b/src/test/java/org/xmlresolver/MyXMLReaderSupplier.java
@@ -1,0 +1,29 @@
+package org.xmlresolver;
+
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.util.function.Supplier;
+
+public class MyXMLReaderSupplier {
+    public static int parserCount = 0;
+
+    public static Supplier<XMLReader> supplier() {
+        return () -> {
+            parserCount++;
+            try {
+                SAXParserFactory factory = SAXParserFactory.newInstance();
+                factory.setNamespaceAware(true);
+                factory.setValidating(false);
+                factory.setXIncludeAware(false);
+                SAXParser parser = factory.newSAXParser();
+                return parser.getXMLReader();
+            } catch (ParserConfigurationException | SAXException ex) {
+                return null;
+            }
+        };
+    }
+}

--- a/src/test/java/org/xmlresolver/XMLResolverConfigurationTest.java
+++ b/src/test/java/org/xmlresolver/XMLResolverConfigurationTest.java
@@ -10,6 +10,7 @@
 package org.xmlresolver;
 
 import org.junit.Test;
+import org.xml.sax.XMLReader;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -17,8 +18,10 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -364,6 +367,43 @@ public class XMLResolverConfigurationTest {
 
         // n.b. make a copy because System.setProperties does not!
         System.setProperties(copyProperties(savedProperties));
+    }
+
+    @Test
+    public void testSAXParserFactoryClass() {
+        String name = "xml.catalog.saxParserFactoryClass";
+        String value = System.getProperty(name);
+        System.setProperty(name, "org.xmlresolver.MySAXParserFactory");
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        XMLReader reader = config.getFeature(ResolverFeature.XMLREADER_SUPPLIER).get();
+        assertTrue(MySAXParserFactory.parserCount > 0);
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
+    }
+
+    @Test
+    public void testXmlReaderSupplier() {
+        String name = "xml.catalog.saxParserFactoryClass";
+        String value = System.getProperty(name);
+        System.setProperty(name, "org.xmlresolver.MySAXParserFactory");
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+
+        Supplier<XMLReader> defaultSupplier = config.getFeature(ResolverFeature.XMLREADER_SUPPLIER);
+        config.setFeature(ResolverFeature.XMLREADER_SUPPLIER, MyXMLReaderSupplier.supplier());
+
+        assertNull(config.getFeature(ResolverFeature.SAXPARSERFACTORY_CLASS));
+
+        XMLReader reader = config.getFeature(ResolverFeature.XMLREADER_SUPPLIER).get();
+        assertTrue(MyXMLReaderSupplier.parserCount > 0);
+
+        if (value == null) {
+            System.clearProperty(name);
+        } else {
+            System.setProperty(name, value);
+        }
     }
 
 }


### PR DESCRIPTION
These features allow you to specify how the resolver gets a parser if it needs one. At the API level, `XMLREADER_SUPPLIER`  lets you construct an `XMLReader` when required and can be configured with a lambda. The `SAXPARSERFACTORY_CLASS` uses the "class with a zero argument constructor" approach which allows it to be specified as a system property or in a configuration file.

Close  #91