### PR TITLE
PR #94 from @tuxji (was Update dependencies and fix compilation errors due to API changes)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
   id "java"
   id "maven-publish"
   id "signing"
-  id 'com.github.gmazzo.buildconfig' version "2.0.2"
-  id 'com.nwalsh.gradle.saxon.saxon-gradle' version '0.9.3'
+  id 'com.github.gmazzo.buildconfig' version "3.0.3"
+  id 'com.nwalsh.gradle.saxon.saxon-gradle' version '0.9.6'
   id 'com.nwalsh.gradle.docker.container' version '0.0.5'
 }
 
@@ -31,13 +31,13 @@ configurations {
 
 dependencies {
   implementation (
-    [group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'],
-    [group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.13'],
+    [group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.1.3'],
+    [group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.1.3'],
     [group: 'xml-apis', name: 'xml-apis', version: '1.4.01' ]
   )
 
   compileOnly (
-    [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30' ]
+    [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36' ]
   )
 
   validatingImplementation (
@@ -45,8 +45,8 @@ dependencies {
   )
 
   testImplementation (
-    [group: 'junit', name: 'junit', version: '4.12'],
-    [group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30' ],
+    [group: 'junit', name: 'junit', version: '4.13.2'],
+    [group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36' ],
     // Because reasons: https://blog.adamretter.org.uk/xerces-xsd11-maven/
     [group: 'org.exist-db.thirdparty.xerces', name: 'xercesImpl', version: '2.12.2' ],
     files("src/test/resources/data1.jar"),

--- a/src/main/java/org/xmlresolver/cache/ResourceCache.java
+++ b/src/main/java/org/xmlresolver/cache/ResourceCache.java
@@ -742,7 +742,7 @@ public class ResourceCache extends CatalogManager {
             return null;
         }
 
-        URI name = connection.getURI();
+        URI name = connection.getUri();
         if (nature == null && purpose == null) {
             logger.log(AbstractLogger.CACHE, "Caching resource for uri: %s", name);
         } else {
@@ -806,11 +806,11 @@ public class ResourceCache extends CatalogManager {
         try {
             lock.lock();
         } catch (IOException ex) {
-            logger.log(AbstractLogger.ERROR, "Failed to obtain directory lock to cache resource: %s", connection.getURI());
+            logger.log(AbstractLogger.ERROR, "Failed to obtain directory lock to cache resource: %s", connection.getUri());
             return null;
         }
 
-        URI name = connection.getURI();
+        URI name = connection.getUri();
         String contentType = connection.getContentType();
         InputStream resource = connection.getStream();
 


### PR DESCRIPTION
This PR is a functionally a copy of 94 from @tuxji:

> Even though I don't use xml-resolver directly, a program I use (Apache Daffodil) depends on Saxon-HE, which in turn depends on xml-resolver, and xml-resolver brings in some transitive dependencies which are older than I want to see. This PR updates these dependencies and fixes compilation errors due to API changes.
> 
> build.gradle: Update dependencies to latest versions (except xml-apis, which causes a puzzling build warning):
> com.github.gmazzo.buildconfig 2.0.2 -> 3.0.3
> com.nwalsh.gradle.saxon.saxon-gradle 0.9.3 -> 0.9.6
> org.apache.httpcomponents httpclient 4.5.13 -> org.apache.httpcomponents.client5 httpclient5 5.1.3
> org.apache.httpcomponents httpcore 4.4.13 -> org.apache.httpcomponents.core5 httpcore5 5.1.3
> org.slf4j slf4j-api 1.7.30 -> 1.7.36
> junit 4.12 -> 4.13.2
> org.slf4j slf4j-simple 1.7.30 -> 1.7.36
> 
> ResourceConnection.java: Fix compilation errors due to incompatible Apache HttpClient API changes between 4.x and 5.x.
> 
> ResourceCache.java: Fix compilation errors due to incompatible Apache HttpClient API changes between 4.x and 5.x.

I clumsily introduced a merge conflict working on the `XercesResolver` so I couldn't (easily) just merge 94. Fix #94 