### PR TITLE
Add a SAX API for adding catalogs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   )
 
   validatingImplementation (
-    [group: 'org.relaxng', name: 'jing', version: '20181222' ]
+    [group: 'org.relaxng', name: 'jing', version: '20220510' ]
   )
 
   testImplementation (

--- a/src/main/java/org/xmlresolver/CatalogManager.java
+++ b/src/main/java/org/xmlresolver/CatalogManager.java
@@ -7,6 +7,7 @@ import org.xmlresolver.loaders.CatalogLoader;
 import org.xmlresolver.logging.AbstractLogger;
 import org.xmlresolver.logging.ResolverLogger;
 import org.xmlresolver.utils.PublicId;
+import org.xmlresolver.utils.SaxProducer;
 import org.xmlresolver.utils.URIUtils;
 
 import java.lang.reflect.Constructor;
@@ -145,6 +146,23 @@ public class CatalogManager implements XMLCatalogResolver {
      */
     public EntryCatalog loadCatalog(URI catalog, InputSource source)  {
         return catalogLoader.loadCatalog(catalog, source);
+    }
+
+    /**
+     * Load the specified catalog by sending events to the ContentHandler.
+     *
+     * <p>This method exists so that a catalog can be loaded even if it doesn't have a URI
+     * that can be dereferenced. It must still have a URI.</p>
+     *
+     * <p>The manager maintains a set of the catalogs that it has loaded. If an attempt is
+     * made to load a catalog twice, the previously loaded catalog is returned.</p>
+     *
+     * @param catalog The catalog URI.
+     * @param producer The producer that delivers events to the ContentHandler.
+     * @return The parsed catalog.
+     */
+    public EntryCatalog loadCatalog(URI catalog, SaxProducer producer)  {
+        return catalogLoader.loadCatalog(catalog, producer);
     }
 
     /**

--- a/src/main/java/org/xmlresolver/loaders/CatalogLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/CatalogLoader.java
@@ -3,6 +3,7 @@ package org.xmlresolver.loaders;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xmlresolver.catalog.entry.EntryCatalog;
+import org.xmlresolver.utils.SaxProducer;
 
 import java.net.URI;
 
@@ -42,6 +43,21 @@ public interface CatalogLoader {
      * @return The parsed catalog.
      */
     public EntryCatalog loadCatalog(URI catalog, InputSource source);
+
+    /**
+     * Load the specified catalog by sending events to the ContentHandler.
+     *
+     * <p>This method exists so that a catalog can be loaded even if it doesn't have a URI
+     * that can be dereferenced. It must still have a URI.</p>
+     *
+     * <p>The manager maintains a set of the catalogs that it has loaded. If an attempt is
+     * made to load a catalog twice, the previously loaded catalog is returned.</p>
+     *
+     * @param catalog The catalog URI.
+     * @param producer The producer that delivers events to the ContentHandler.
+     * @return The parsed catalog.
+     */
+    public EntryCatalog loadCatalog(URI catalog, SaxProducer producer);
 
     /** Set the default "prefer public" status for this catalog.
      *

--- a/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
@@ -84,6 +84,7 @@ public class ValidatingXmlLoader implements CatalogLoader {
     /** Load the specified catalog from the specified stream.
      *
      * @param catalog The catalog URI.
+     * @param source The input source.
      * @return The parsed catalog, if it was available and valid.
      * @throws CatalogInvalidException if the catalog is invalid.
      */

--- a/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
@@ -188,7 +188,8 @@ public class ValidatingXmlLoader implements CatalogLoader {
                     throw new CatalogInvalidException("Failed to load catalog schema: " + errorHandler.getMessage());
                 }
             }
-            if (!driver.validate(producer)) {
+
+            if (!driver.validate(SaxProducer.adaptForJing(producer))) {
                 String msg = errorHandler.getMessage();
                 throw new CatalogInvalidException("Catalog '" + catalog.toString() + "' is invalid: " + msg);
             };

--- a/src/main/java/org/xmlresolver/utils/SaxProducer.java
+++ b/src/main/java/org/xmlresolver/utils/SaxProducer.java
@@ -1,0 +1,30 @@
+package org.xmlresolver.utils;
+
+import org.xml.sax.ContentHandler;
+import org.xml.sax.DTDHandler;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+/**
+ * Similar to {@link java.util.function.Consumer} but
+ * permits an IOException or a SAXException to be thrown.
+ *
+ * Influenced by <a href="https://github.com/evolvedbinary/j8fu/blob/master/src/main/java/com/evolvedbinary/j8fu/function/TriConsumer2E.java">TriConsumer2E&lt;ContentHandler, IOException, SAXException&gt;</a>
+ */
+@FunctionalInterface
+public interface SaxProducer {
+
+    /**
+     * Causes the producer to process and send SAX events.
+     *
+     * @param contentHandler the Content Handler
+     * @param dtdHandler the DTD handler, or null if absent.
+     * @param errorHandler the error handler, or null if absent.
+     *
+     * @throws IOException if an error occurs during processing
+     * @throws SAXException if a SAXException occurs when calling one of the handlers
+     */
+    void produce(ContentHandler contentHandler, DTDHandler dtdHandler, ErrorHandler errorHandler) throws IOException, SAXException;
+}

--- a/src/main/java/org/xmlresolver/utils/SaxProducer.java
+++ b/src/main/java/org/xmlresolver/utils/SaxProducer.java
@@ -27,4 +27,31 @@ public interface SaxProducer {
      * @throws SAXException if a SAXException occurs when calling one of the handlers
      */
     void produce(ContentHandler contentHandler, DTDHandler dtdHandler, ErrorHandler errorHandler) throws IOException, SAXException;
+
+    /**
+     * Adapt the provided XMLResolver SaxProducer to a Jing SaxProducer.
+     *
+     * @param saxProducer the XMLResolver SaxProducer.
+     *
+     * @return the Jing SaxProducer.
+     */
+    static com.thaiopensource.validate.ValidationDriver.SaxProducer adaptForJing(final SaxProducer saxProducer) {
+        return new SaxProducerJingAdapter(saxProducer);
+    }
+
+    /**
+     * Simple adapter for XMLResolver SaxProducer to Jing SaxProducer.
+     */
+    static class SaxProducerJingAdapter implements com.thaiopensource.validate.ValidationDriver.SaxProducer {
+        private final SaxProducer saxProducer;
+
+        public SaxProducerJingAdapter(final SaxProducer saxProducer) {
+            this.saxProducer = saxProducer;
+        }
+
+        @Override
+        public void produce(final ContentHandler contentHandler, final DTDHandler dtdHandler, final ErrorHandler errorHandler) throws IOException, SAXException {
+            saxProducer.produce(contentHandler, dtdHandler, errorHandler);
+        }
+    }
 }


### PR DESCRIPTION
**NOTE** this requires https://github.com/relaxng/jing-trang/pull/265

This adds an API to the CatalogLoader for directly loading catalogues with SAX.

The issue I face without this is that within our XML Native Databases (i.e. eXist-db, Elemental, and FusionDB), XML documents are stored as a stream of SAX-like events.

When we wish to retrieve a document from the XML Native Database, we may do so using either SAX, StaX, or a lazy persistent like DOM approach.

However, all of the APIs for XML Resolver's catalogs require a file path or SAX `InputSource`. There are no files, as all the documents are in the database, and unfortunately a SAX `InputSource` requires you to take your XML data from either a `Reader`, `InputStream`, or `URI` (systemId)!

If we were to use an `InputSource` to take our data from the database, we would first have to first serialize our XML document from the database into a character stream stored on disk (or possibly in-memory), and then provide that to XMLResolver. XMLResolver would then have to deserialize that using an XMLReader to create a series of SAX events.

As our database can produce SAX events when reading a document, it is much more efficient to connect the two directly via SAX than it is to do a serialize and deserialize dance in the middle between the database and XMLResolver.

I hope that makes sense, let me know if you have any questions - my changes are small and attempt to be as unobtrusive as possible! Kind regards :-)