### PR TITLE
fix NPE when resolving schema resource w/o systemId

### DIFF
--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -139,7 +139,9 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
                 purpose = PURPOSE_SCHEMA_VALIDATION;
             }
 
-            rsrc = resolver.resolveNamespace(systemId, baseURI, type, purpose);
+            if(systemId != null ) {
+                rsrc = resolver.resolveNamespace(systemId, baseURI, type, purpose);
+            }
         }
 
         if (rsrc == null) {

--- a/src/test/java/org/xmlresolver/ResolverTest.java
+++ b/src/test/java/org/xmlresolver/ResolverTest.java
@@ -122,7 +122,7 @@ public class ResolverTest {
                 baseURI.toASCIIString()
         );
 
-        assertNull("null expected if neither systemId nor publicId are specified", result);
+        assertNull("null expected if schema resource is requested w/o systemId", result);
     }
 
 }

--- a/src/test/java/org/xmlresolver/ResolverTest.java
+++ b/src/test/java/org/xmlresolver/ResolverTest.java
@@ -9,6 +9,7 @@ package org.xmlresolver;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.w3c.dom.ls.LSInput;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.DefaultHandler2;
@@ -106,4 +107,22 @@ public class ResolverTest {
             fail();
         }
     }
+
+    @Test
+    public void testSchemaWithoutSystemIdReturnsNull() {
+        URI baseURI = URIUtils.cwd().resolve("src/test/resources/sample10/sample.xsd");
+        XMLResolverConfiguration rconfig = new XMLResolverConfiguration("src/test/resources/rescatxsd.xml");
+        Resolver resolver = new Resolver(rconfig);
+
+        LSInput result = resolver.resolveResource(
+                "http://www.w3.org/2001/XMLSchema",
+                "http://xmlresolver.org/some/custom/namespace",
+                null,
+                null,
+                baseURI.toASCIIString()
+        );
+
+        assertNull("null expected if neither systemId nor publicId are specified", result);
+    }
+
 }


### PR DESCRIPTION
Return `null` when the `LSResourceResolver` implementation is called with the schema type URI but no systemId.

Addresses #99.