### PR TITLE
Updated Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -221,7 +221,7 @@ task dataJar(type: Jar, dependsOn: ["copyData"]) {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver data"
     attributes "Implementation-Version": resolverVersion
-    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver-data"
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver_data"
   }
 }
 assemble.dependsOn dataJar


### PR DESCRIPTION
"-" is not allowed in Java Module Names
(see e.g. https://sormuras.github.io/blog/2018-11-16-invalid-automatic-module-names)

Error Message: java.lang.module.FindException: Automatic-Module-Name: org.xmlresolver.xmlresolver-data: Invalid module name: 'xmlresolver-data' is not a Java identifier