### PR TITLE
Added a feature to fix windows system identifiers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver API documentation"
     attributes "Implementation-Version": resolverVersion
-    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver-javadoc"
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver_javadoc"
   }
 }
 assemble.dependsOn javadocJar
@@ -207,7 +207,7 @@ task sourcesJar(type: Jar, dependsOn: ["generateBuildConfig"]) {
     attributes "Implementation-Vendor": "Norman Walsh"
     attributes "Implementation-Title": "XML Resolver sources"
     attributes "Implementation-Version": resolverVersion
-    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver-sources"
+    attributes "Automatic-Module-Name": "org.xmlresolver.xmlresolver_sources"
   }
 }
 assemble.dependsOn sourcesJar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=4.3.0
+resolverVersion=4.4.0
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/CatalogManager.java
+++ b/src/main/java/org/xmlresolver/CatalogManager.java
@@ -149,6 +149,13 @@ public class CatalogManager implements XMLCatalogResolver {
         return new QueryUri(uri, nature, purpose).search(this).uri();
     }
 
+    private String fixWindowsSystemIdentifier(String systemId) {
+        if (URIUtils.isWindows() && resolverConfiguration.getFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS)) {
+            systemId = systemId.replace("\\", "/");
+        }
+        return systemId;
+    }
+
     /**
      * Lookup the specified system and public identifiers in the catalog.
      *
@@ -168,6 +175,7 @@ public class CatalogManager implements XMLCatalogResolver {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public URI lookupPublic(String systemId, String publicId) {
+        systemId = fixWindowsSystemIdentifier(systemId);
         ExternalIdentifiers external = normalizeExternalIdentifiers(systemId, publicId);
         return new QueryPublic(external.systemId, external.publicId).search(this).uri();
     }
@@ -188,6 +196,7 @@ public class CatalogManager implements XMLCatalogResolver {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public URI lookupSystem(String systemId) {
+        systemId = fixWindowsSystemIdentifier(systemId);
         ExternalIdentifiers external = normalizeExternalIdentifiers(systemId, null);
         if (external.systemId == null) {
             return null;
@@ -213,6 +222,7 @@ public class CatalogManager implements XMLCatalogResolver {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public URI lookupDoctype(String entityName, String systemId, String publicId) {
+        systemId = fixWindowsSystemIdentifier(systemId);
         ExternalIdentifiers external = normalizeExternalIdentifiers(systemId, publicId);
         return new QueryDoctype(entityName, external.systemId, external.publicId).search(this).uri();
     }
@@ -243,6 +253,7 @@ public class CatalogManager implements XMLCatalogResolver {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public URI lookupEntity(String entityName, String systemId, String publicId) {
+        systemId = fixWindowsSystemIdentifier(systemId);
         ExternalIdentifiers external = normalizeExternalIdentifiers(systemId, publicId);
         return new QueryEntity(entityName, external.systemId, external.publicId).search(this).uri();
     }
@@ -261,6 +272,7 @@ public class CatalogManager implements XMLCatalogResolver {
      * @return The mapped value, or <code>null</code> if no matching entry is found.
      */
     public URI lookupNotation(String notationName, String systemId, String publicId) {
+        systemId = fixWindowsSystemIdentifier(systemId);
         ExternalIdentifiers external = normalizeExternalIdentifiers(systemId, publicId);
         return new QueryNotation(notationName, external.systemId, external.publicId).search(this).uri();
     }

--- a/src/main/java/org/xmlresolver/CatalogResolver.java
+++ b/src/main/java/org/xmlresolver/CatalogResolver.java
@@ -209,6 +209,14 @@ public class CatalogResolver implements ResourceResolver {
         }
 
         if (systemId != null) {
+            if (URIUtils.isWindows() && config.getFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS)) {
+                systemId = systemId.replace("\\", "/");
+                // The base URI may be wrong too...
+                if (baseURI != null) {
+                    baseURI = baseURI.replace("\\", "/");
+                }
+            }
+
             try {
                 URI uri = new URI(systemId);
                 if (uri.isAbsolute()) {

--- a/src/main/java/org/xmlresolver/ResolverFeature.java
+++ b/src/main/java/org/xmlresolver/ResolverFeature.java
@@ -415,4 +415,16 @@ public class ResolverFeature<T> {
             return null;
         }
     });
+
+    /**
+     * Fix backslashes in system identifiers on Windows?
+     * <p>System identifiers are URIs and URIs may not contain un-escaped backslashes. However, Windows
+     * uses the backslash as the path separator and it's not uncommon for filenames to appear in system
+     * identifiers. If this flag is set, the resolver will coerce backslashes into forward slashes in
+     * system identifiers.</p>
+     */
+    public static final ResolverFeature<Boolean> FIX_WINDOWS_SYSTEM_IDENTIFIERS = new ResolverFeature<>(
+            "http://xmlresolver.org/feature/fix-windows-system-identifiers", false);
+
+
 }

--- a/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
+++ b/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
@@ -181,7 +181,8 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             ResolverFeature.RESOLVER_LOGGER_CLASS, ResolverFeature.RESOLVER_LOGGER,
             ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL,
             ResolverFeature.ACCESS_EXTERNAL_ENTITY, ResolverFeature.ACCESS_EXTERNAL_DOCUMENT,
-            ResolverFeature.SAXPARSERFACTORY_CLASS, ResolverFeature.XMLREADER_SUPPLIER};
+            ResolverFeature.SAXPARSERFACTORY_CLASS, ResolverFeature.XMLREADER_SUPPLIER,
+            ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS};
 
     private static List<String> classpathCatalogList = null;
 
@@ -211,6 +212,7 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
     private String accessExternalDocument = ResolverFeature.ACCESS_EXTERNAL_DOCUMENT.getDefaultValue();
     private String saxParserFactoryClass = ResolverFeature.SAXPARSERFACTORY_CLASS.getDefaultValue();
     private Supplier<XMLReader> xmlReaderSupplier = ResolverFeature.XMLREADER_SUPPLIER.getDefaultValue();
+    private Boolean fixWindowsSystemIdentifiers = ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS.getDefaultValue();
     private ResolverLogger resolverLogger = null;
 
     /** Construct a default configuration.
@@ -543,6 +545,12 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             showConfigChange("SAXParserFactory class: %s", property);
             saxParserFactoryClass = property;
         }
+
+        property = System.getProperty("xml.catalog.fixWindowsSystemIdentifiers");
+        if (property != null) {
+            showConfigChange("Fix windows system identifiers: %s", property);
+            fixWindowsSystemIdentifiers = isTrue(property);
+        }
     }
 
     private void loadPropertiesConfiguration(URL propertiesURL, Properties properties) {
@@ -715,6 +723,12 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             showConfigChange("SAXParserFactory class: %s", property);
             saxParserFactoryClass = property;
         }
+
+        property = properties.getProperty("fix-windows-system-identifiers");
+        if (property != null) {
+            showConfigChange("Fix windows system identifiers: %s", property);
+            fixWindowsSystemIdentifiers = isTrue(property);
+        }
     }
 
     private void showConfig() {
@@ -739,6 +753,7 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         resolverLogger.log(AbstractLogger.CONFIG, "Access external document: %s", accessExternalDocument);
         resolverLogger.log(AbstractLogger.CONFIG, "SAXParserFactory class: %s", saxParserFactoryClass);
         resolverLogger.log(AbstractLogger.CONFIG, "XMLReader supplier: %s", xmlReaderSupplier);
+        resolverLogger.log(AbstractLogger.CONFIG, "Fix Windows system identifiers: %s", fixWindowsSystemIdentifiers);
 
         resolverLogger.log(AbstractLogger.CONFIG, "Default logger log level: %s", defaultLoggerLogLevel);
         for (String catalog: catalogs) {
@@ -959,6 +974,9 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             saxParserFactoryClass = null;
             xmlReaderSupplier = (Supplier<XMLReader>) value;
             showConfigChange("XMLReader supplier: %s", xmlReaderSupplier);
+        } else if (feature == ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS) {
+            fixWindowsSystemIdentifiers = (Boolean) value;
+            showConfigChange("Fix windows system identifiers: %s", fixWindowsSystemIdentifiers);
         } else {
             resolverLogger.log(AbstractLogger.ERROR, "Ignoring unknown feature: %s", feature.getName());
         }
@@ -1114,6 +1132,8 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             return (T) saxParserFactoryClass;
         } else if (feature == ResolverFeature.XMLREADER_SUPPLIER) {
             return (T) xmlReaderSupplier;
+        } else if (feature == ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS) {
+            return (T) fixWindowsSystemIdentifiers;
         } else {
             resolverLogger.log(AbstractLogger.ERROR, "Ignoring unknown feature: %s", feature.getName());
             return null;
@@ -1138,8 +1158,8 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
     }
 
     private static class FallbackLogger extends AbstractLogger {
-        private ArrayList<Message> messages = new ArrayList<>();
-        private String fallbackLogging = System.getProperty("xml.catalog.FallbackLoggerLogLevel");
+        private final ArrayList<Message> messages = new ArrayList<>();
+        private final String fallbackLogging = System.getProperty("xml.catalog.FallbackLoggerLogLevel");
 
 
         @Override

--- a/src/main/java/org/xmlresolver/utils/URIUtils.java
+++ b/src/main/java/org/xmlresolver/utils/URIUtils.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 public abstract class URIUtils {
     private static Boolean isWindows = null;
 
-    private static boolean checkWindows() {
+    public static boolean isWindows() {
         if (isWindows == null) {
             String os = System.getProperty("os.name", "unknown").toLowerCase();
             isWindows = os.contains("win");
@@ -29,7 +29,7 @@ public abstract class URIUtils {
     }
 
     private static String windowsPathURI(String uri) {
-        if (!checkWindows()) {
+        if (!isWindows()) {
             return uri;
         }
         String fixSlashes = uri.replaceAll("\\\\", "/");


### PR DESCRIPTION
Added a `FIX_WINDOWS_SYSTEM_IDENTIFIERS` feature. If true, on Windows systems, backslash characters in system identifiers are replaced with forward slashes before resolution is attempted. This avoids a URI syntax exception caused by the fact that, technically, backslashes are not allowed in URIs. 