### PR TITLE
Fix bug in cache management

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=4.4.0
+resolverVersion=4.4.1
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -43,7 +43,7 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
     public static final String NATURE_XML_SCHEMA_1_1 = "http://www.w3.org/2001/XMLSchema/v1.1";
     public static final String NATURE_RELAX_NG = "http://relaxng.org/ns/structure/1.0";
 
-        private final ResolverLogger logger;
+    private final ResolverLogger logger;
     protected final XMLResolverConfiguration config;
     protected final CatalogResolver resolver;
 

--- a/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
+++ b/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
@@ -870,7 +870,11 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         } else if (feature == ResolverFeature.CACHE_DIRECTORY) {
             cacheDirectory = (String) value;
             showConfigChange("Cache directory: %s", cacheDirectory);
-            cache = null;
+            if (cache == null) {
+                cache = new ResourceCache(this);
+            } else {
+                cache.reset();
+            }
             return;
         } else if (feature == ResolverFeature.CACHE) {
             cache = (ResourceCache) value;
@@ -894,11 +898,19 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         } else if (feature == ResolverFeature.CACHE_UNDER_HOME) {
             cacheUnderHome = (Boolean) value;
             showConfigChange("Cache under home: %s", cacheUnderHome);
-            cache = null;
+            if (cache == null) {
+                cache = new ResourceCache(this);
+            } else {
+                cache.reset();
+            }
         } else if (feature == ResolverFeature.CACHE_ENABLED) {
             cacheEnabled = (Boolean) value;
             showConfigChange("Cache enabled: %s", cacheEnabled);
-            cache = null;
+            if (cache == null) {
+                cache = new ResourceCache(this);
+            } else {
+                cache.reset();
+            }
         } else if (feature == ResolverFeature.CATALOG_MANAGER) {
             manager = (CatalogManager) value;
             resolverLogger.log(AbstractLogger.CONFIG, "Catalog manager: %s", manager.toString());

--- a/src/main/java/org/xmlresolver/cache/ResourceCache.java
+++ b/src/main/java/org/xmlresolver/cache/ResourceCache.java
@@ -22,6 +22,7 @@ import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -130,16 +131,25 @@ public class ResourceCache extends CatalogManager {
     private File entryDir = null;
     private File expiredDir = null;
 
-    private final CacheParser cacheParser;
+    private final ResolverConfiguration config;
     private final ArrayList<CacheInfo> cacheInfo = new ArrayList<> ();
 
+    private CacheParser cacheParser = null;
     private CacheEntryCatalog catalog = null;
     private CacheInfo defaultCacheInfo = null;
     private String cacheVersion = null;
 
     public ResourceCache(ResolverConfiguration config) {
         super(config);
+        this.config = config;
+        reset();
+    }
 
+    /** Reset the cache configuration.
+     * <p>If the cache configuration is changed, calling <code>reset</code> will adjust
+     * this cache to reflect the new settings.</p>
+     */
+    public void reset() {
         if (!config.getFeature(ResolverFeature.CACHE_ENABLED)) {
             cacheDir = null;
             cacheParser = null;
@@ -238,7 +248,7 @@ public class ResourceCache extends CatalogManager {
 
         File control = new File(cacheDir, "control.xml");
         try {
-            PrintStream ps = new PrintStream(new FileOutputStream(control));
+            PrintStream ps = new PrintStream(Files.newOutputStream(control.toPath()));
             ps.println("<cache-control version='2' xmlns='" + ResolverConstants.XMLRESOURCE_EXT_NS + "'>");
             for (CacheInfo info : cacheInfo) {
                 if (info.cache) {

--- a/src/test/java/org/xmlresolver/CacheTest.java
+++ b/src/test/java/org/xmlresolver/CacheTest.java
@@ -2,17 +2,14 @@ package org.xmlresolver;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.xml.sax.InputSource;
 import org.xmlresolver.cache.CacheInfo;
 import org.xmlresolver.cache.ResourceCache;
 import org.xmlresolver.utils.URIUtils;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class CacheTest extends CacheManager {
     private static final String cacheDir = "build/test-cache";
@@ -146,6 +143,26 @@ public class CacheTest extends CacheManager {
         } else {
             System.setProperty("xml.catalog.cacheEnabled", value);
         }
+    }
+
+    @Test
+    public void testCacheDisabledAfterInitialization() {
+        try {
+            XMLResolverConfiguration localConfig = new XMLResolverConfiguration();
+            assertTrue(localConfig.getFeature(ResolverFeature.CACHE_ENABLED));
+
+            Resolver resolver = new Resolver(localConfig);
+            resolver.getConfiguration().setFeature(ResolverFeature.CACHE_ENABLED, false);
+
+            InputSource source = resolver.resolveEntity(null, "https://jats.nlm.nih.gov/publishing/1.3/JATS-journalpublishing1-3.dtd");
+            assertNull(source);
+
+            source = resolver.resolveEntity(null, "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd");
+            assertNotNull(source);
+        } catch (Exception ex) {
+            fail();
+        }
+
     }
 
 

--- a/src/test/java/org/xmlresolver/CatalogSpacesTest.java
+++ b/src/test/java/org/xmlresolver/CatalogSpacesTest.java
@@ -23,6 +23,7 @@ public class CatalogSpacesTest {
         config = new XMLResolverConfiguration(catalog);
         config.setFeature(ResolverFeature.CACHE_DIRECTORY, null);
         config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
+        config.setFeature(ResolverFeature.CACHE_ENABLED, false);
         resolver = new Resolver(config);
 
         // Make sure the Docker container is running where we expect.

--- a/src/test/java/org/xmlresolver/FeatureTest.java
+++ b/src/test/java/org/xmlresolver/FeatureTest.java
@@ -66,7 +66,12 @@ public class FeatureTest {
 
     @Test
     public void testFeatureCacheDirectory() {
-        stringFeature(ResolverFeature.CACHE_DIRECTORY);
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        knownFeature(config, ResolverFeature.CACHE_DIRECTORY);
+        String orig = config.getFeature(ResolverFeature.CACHE_DIRECTORY);
+        config.setFeature(ResolverFeature.CACHE_DIRECTORY, "/tmp/apple pie");
+        Assert.assertEquals("/tmp/apple pie", config.getFeature(ResolverFeature.CACHE_DIRECTORY));
+        config.setFeature(ResolverFeature.CACHE_DIRECTORY, orig);
     }
 
     @Test

--- a/src/test/java/org/xmlresolver/RddlTest.java
+++ b/src/test/java/org/xmlresolver/RddlTest.java
@@ -135,6 +135,7 @@ public class RddlTest extends CacheManager {
         XMLResolverConfiguration config = new XMLResolverConfiguration("src/test/resources/catalog.xml");
         config.setFeature(ResolverFeature.CACHE_DIRECTORY, null);
         config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
+        config.setFeature(ResolverFeature.CACHE_ENABLED, false);
         config.setFeature(ResolverFeature.PARSE_RDDL, true);
         CatalogResolver resolver = new CatalogResolver(config);
 

--- a/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
+++ b/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
@@ -35,6 +35,7 @@ public class ResolverTestLocalhost extends CacheManager {
         config = new XMLResolverConfiguration("src/test/resources/domresolver.xml");
         config.setFeature(ResolverFeature.CACHE_DIRECTORY, null);
         config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
+        config.setFeature(ResolverFeature.CACHE_ENABLED, false);
 
         // Make sure the Docker container is running where we expect.
         ResourceConnection conn = new ResourceConnection(config, "http://localhost:8222/docs/sample/sample.dtd", true);
@@ -60,10 +61,8 @@ public class ResolverTestLocalhost extends CacheManager {
         // These aren't found in the catalog
 
         Source source = resolver.resolve("http://localhost:8222/docs/sample/sample.xsl","file:/tmp/test.xsl");
-        System.err.println("SOURCE1: " + source);
         assertNull(source);
         source = resolver.resolve("../helloworld.xml","http://localhost:8222/docs/sample/sample.xsl");
-        System.err.println("SOURCE1: " + source);
         assertNull(source);
     }
 

--- a/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
+++ b/src/test/java/org/xmlresolver/ResolverTestLocalhost.java
@@ -60,8 +60,10 @@ public class ResolverTestLocalhost extends CacheManager {
         // These aren't found in the catalog
 
         Source source = resolver.resolve("http://localhost:8222/docs/sample/sample.xsl","file:/tmp/test.xsl");
+        System.err.println("SOURCE1: " + source);
         assertNull(source);
         source = resolver.resolve("../helloworld.xml","http://localhost:8222/docs/sample/sample.xsl");
+        System.err.println("SOURCE1: " + source);
         assertNull(source);
     }
 

--- a/src/test/java/org/xmlresolver/XercesResolverTest.java
+++ b/src/test/java/org/xmlresolver/XercesResolverTest.java
@@ -43,6 +43,7 @@ public class XercesResolverTest {
         config.setFeature(ResolverFeature.CACHE, null);
         config.setFeature(ResolverFeature.CACHE_DIRECTORY, null);
         config.setFeature(ResolverFeature.CACHE_UNDER_HOME, false);
+        config.setFeature(ResolverFeature.CACHE_ENABLED, false);
         resolver = new XercesResolver(config);
     }
 


### PR DESCRIPTION
Fix #104 

If a cache property is changed (for example, disabling the cache), that should have immediate effect on (all) of the resolvers using the configured cache. Also fixed a whitespace issue and bumped the version.
