### PR TITLE
Update to XML Resolver Data version 1.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=4.4.2
+resolverVersion=4.4.3
 
 group=org.xmlresolver
 

--- a/src/test/java/org/xmlresolver/DataTest.java
+++ b/src/test/java/org/xmlresolver/DataTest.java
@@ -280,7 +280,7 @@ public class DataTest {
 
     @Test
     public void gen_lookupSystemd1e84() {
-        URI result = manager.lookupSystem("https://www.w3.org/2001/datatypes.xsd");
+        URI result = manager.lookupSystem("https://www.w3.org/2001/datatypes.dtd");
         assertNotNull(result);
     }
 
@@ -946,7 +946,7 @@ public class DataTest {
 
     @Test
     public void gen_lookupSystemd1e257() {
-        URI result = manager.lookupSystem("https://www.w3.org/2009/XMLSchema/datatypes.xsd");
+        URI result = manager.lookupSystem("https://www.w3.org/2009/XMLSchema/datatypes.dtd");
         assertNotNull(result);
     }
 

--- a/src/test/resources/entity-fail.xml
+++ b/src/test/resources/entity-fail.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE doc SYSTEM "entity-test.dtd">
+<doc>
+<para>&fork;</para>
+</doc>

--- a/src/test/resources/entity-test.dtd
+++ b/src/test/resources/entity-test.dtd
@@ -1,0 +1,3 @@
+<!ENTITY spoon "Spoon!">
+<!ELEMENT doc (para+)>
+<!ELEMENT para (#PCDATA)*>

--- a/src/test/resources/entity-test.xml
+++ b/src/test/resources/entity-test.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE doc SYSTEM "entity-test.dtd">
+<doc>
+<para>&spoon;</para>
+</doc>


### PR DESCRIPTION
This fixes a few issues surrounding access to the W3C XML Schema DTDs from unofficial locations at w3.org.