### PR TITLE
Encode (but don't double-encode) catalog filenames

### DIFF
--- a/src/main/java/org/xmlresolver/CatalogManager.java
+++ b/src/main/java/org/xmlresolver/CatalogManager.java
@@ -85,6 +85,7 @@ public class CatalogManager implements XMLCatalogResolver {
     public List<URI> catalogs() {
         ArrayList<URI> catlist = new ArrayList<>();
         for (String cat : resolverConfiguration.getFeature(ResolverFeature.CATALOG_FILES)) {
+            cat = URIUtils.normalizeURI(cat);
             catlist.add(URIUtils.cwd().resolve(cat));
         }
         return catlist;

--- a/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/ValidatingXmlLoader.java
@@ -58,7 +58,7 @@ public class ValidatingXmlLoader implements CatalogLoader {
         }
 
         try {
-            Resource rsrc = new Resource(catalog.toString());
+            Resource rsrc = new Resource(catalog);
             InputSource source = new InputSource(rsrc.body());
             source.setSystemId(catalog.toString());
             return loadCatalog(catalog, source);

--- a/src/main/java/org/xmlresolver/loaders/XmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/XmlLoader.java
@@ -92,7 +92,7 @@ public class XmlLoader implements CatalogLoader {
         }
 
         try {
-            Resource rsrc = new Resource(catalog.toString());
+            Resource rsrc = new Resource(catalog);
             InputSource source = new InputSource(rsrc.body());
             source.setSystemId(catalog.toString());
             return loadCatalog(catalog, source);

--- a/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
+++ b/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
@@ -234,6 +234,7 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
                 baseURI = URIUtils.cwd().resolve(baseURI);
             }
         } catch (URISyntaxException use) {
+            systemId = URIUtils.normalizeURI(systemId);
             baseURI = URIUtils.cwd().resolve(systemId);
         }
     }

--- a/src/test/java/org/xmlresolver/ResolverTest.java
+++ b/src/test/java/org/xmlresolver/ResolverTest.java
@@ -14,8 +14,10 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.DefaultHandler2;
 import org.xmlresolver.sources.ResolverInputSource;
+import org.xmlresolver.tools.ResolvingXMLReader;
 import org.xmlresolver.utils.URIUtils;
 
+import javax.xml.catalog.Catalog;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
@@ -125,4 +127,17 @@ public class ResolverTest {
         assertNull("null expected if schema resource is requested w/o systemId", result);
     }
 
+    @Test
+    public void issue117() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList(), Collections.singletonList(catalog1));
+        config.setFeature(ResolverFeature.CATALOG_FILES, Collections.singletonList("src/test/resources/projets en développement/catalog.xml"));
+        resolver = new Resolver(config);
+        ResolvingXMLReader reader = new ResolvingXMLReader(resolver);
+        try {
+            String fn = URIUtils.normalizeURI("src/test/resources/projets en développement/xml/instance.xml");
+            reader.parse(URIUtils.cwd().resolve(fn).toString());
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
 }

--- a/src/test/resources/projets en développement/catalog.xml
+++ b/src/test/resources/projets en développement/catalog.xml
@@ -1,0 +1,7 @@
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+
+  <public publicId="-//Sample//DTD Projets et Developpement 1.0//EN"
+          uri="dtd/proj.dtd"/>
+
+</catalog>

--- a/src/test/resources/projets en développement/dtd/proj.dtd
+++ b/src/test/resources/projets en développement/dtd/proj.dtd
@@ -1,0 +1,2 @@
+<!ELEMENT proj (p+)>
+<!ELEMENT p (#PCDATA)*>

--- a/src/test/resources/projets en développement/xml/instance.xml
+++ b/src/test/resources/projets en développement/xml/instance.xml
@@ -1,0 +1,6 @@
+<!DOCTYPE proj
+          PUBLIC "-//Sample//DTD Projets et Developpement 1.0//EN"
+          "http://example.com/this/does/not/exist.dtd">
+<proj>
+<p>This is a test</p>
+</proj>


### PR DESCRIPTION
I hate bugs that have clearly existed for a long time but have never been reported.

If a catalog path contains non-URI characters, then the attempt to load it fails (because `URI.resolve()` objects).

Simply escaping the URI isn't sufficient because later on when we attempt to load the catalog we re-encode it, which results in double escaping.

The fix here is to pass the URI directly to `new Resource()` rather than passing `uri.toString()`.

I haven't removed the string flavors of the `Resource` constructor, but perhaps I should. They will invariably result in double encoding if you pass a URI encoded string to them.

Fix #117 