### PR TITLE
Enforce ACCESS_* features when opening connections

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=5.1.0
+resolverVersion=5.1.1
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/CatalogResolver.java
+++ b/src/main/java/org/xmlresolver/CatalogResolver.java
@@ -506,47 +506,7 @@ public class CatalogResolver implements ResourceResolver {
     }
 
     private boolean forbidAccess(String allowed, String uri) {
-        if (allowed == null || "".equals(allowed.trim())) {
-            return true;
-        }
-
-        if ("all".equals(allowed.trim())) {
-            return false;
-        }
-
-        boolean sawHttp = false;
-        boolean sawHttps = false;
-
-        // Ok, that's the easy cases taken care of. Let's do the hard work.
-        uri = uri.toLowerCase();
-        for (String value : allowed.split(",")) {
-            String protocol = value.trim().toLowerCase();
-
-            if ("all".equals(protocol)) {
-                return false;
-            }
-
-            if (!protocol.endsWith(":")) {
-                protocol += ":";
-            }
-
-            sawHttp = sawHttp || "http:".equals(protocol);
-            sawHttps = sawHttps || "https:".equals(protocol);
-            if (uri.startsWith(protocol)) {
-                return false;
-            }
-        }
-
-        if (config.getFeature(ResolverFeature.MERGE_HTTPS)) {
-            if (sawHttp && !sawHttps && uri.startsWith("https:")) {
-                return false;
-            }
-            if (sawHttps && !sawHttp && uri.startsWith("http:")) {
-                return false;
-            }
-        }
-
-        return true;
+        return URIUtils.forbidAccess(allowed, uri, config.getFeature(ResolverFeature.MERGE_HTTPS));
     }
 
     protected ResolvedResourceImpl resource(String requestURI, URI responseURI, CacheEntry cached) {

--- a/src/main/java/org/xmlresolver/XercesResolver.java
+++ b/src/main/java/org/xmlresolver/XercesResolver.java
@@ -113,17 +113,17 @@ public class XercesResolver extends Resolver implements org.apache.xerces.xni.pa
         }
 
         if (rsrc == null) {
-            rsrc = safeOpenConnection(systemId, baseURI);
+            rsrc = safeOpenConnection(systemId, baseURI, true);
         }
 
         return rsrc == null ? null : new SAXInputSource(new ResolverInputSource(rsrc));
     }
 
-    private ResolvedResource safeOpenConnection(String systemId, String baseURI) {
+    private ResolvedResource safeOpenConnection(String systemId, String baseURI, boolean asEntity) {
         // This is "safe" in the weird sense that it doesn't throw a checked exception
         if (systemId != null && config.getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
             try {
-                return openConnection(systemId, baseURI);
+                return openConnection(systemId, baseURI, asEntity);
             } catch (IOException err) {
                 // What am I supposed to do about this now?
             }
@@ -137,7 +137,7 @@ public class XercesResolver extends Resolver implements org.apache.xerces.xni.pa
             rsrc = resolver.resolveEntity(resId.getRootName(), resId.getPublicId(), resId.getExpandedSystemId(), resId.getBaseSystemId());
         }
         if (rsrc == null) {
-            rsrc = safeOpenConnection(resId.getLiteralSystemId(), resId.getBaseSystemId());
+            rsrc = safeOpenConnection(resId.getLiteralSystemId(), resId.getBaseSystemId(), true);
         }
         return rsrc == null ? null : new SAXInputSource(new ResolverInputSource(rsrc));
     }
@@ -153,7 +153,7 @@ public class XercesResolver extends Resolver implements org.apache.xerces.xni.pa
             rsrc = resolver.resolveEntity(name, resId.getPublicId(), resId.getExpandedSystemId(), resId.getBaseSystemId());
         }
         if (rsrc == null) {
-            rsrc = safeOpenConnection(resId.getLiteralSystemId(), resId.getBaseSystemId());
+            rsrc = safeOpenConnection(resId.getLiteralSystemId(), resId.getBaseSystemId(), true);
         }
         return rsrc == null ? null : new SAXInputSource(new ResolverInputSource(rsrc));
     }
@@ -173,7 +173,7 @@ public class XercesResolver extends Resolver implements org.apache.xerces.xni.pa
         }
 
         if (rsrc == null) {
-            rsrc = safeOpenConnection(resId.getLiteralSystemId(), resId.getBaseSystemId());
+            rsrc = safeOpenConnection(resId.getLiteralSystemId(), resId.getBaseSystemId(), false);
         }
 
         if (rsrc != null) {

--- a/src/main/java/org/xmlresolver/utils/URIUtils.java
+++ b/src/main/java/org/xmlresolver/utils/URIUtils.java
@@ -249,4 +249,48 @@ public abstract class URIUtils {
             return "%" + hex;
         }
     }
+
+    public static boolean forbidAccess(String allowed, String uri, boolean mergeHttps) {
+        if (allowed == null || "".equals(allowed.trim())) {
+            return true;
+        }
+
+        if ("all".equals(allowed.trim())) {
+            return false;
+        }
+
+        boolean sawHttp = false;
+        boolean sawHttps = false;
+
+        // Ok, that's the easy cases taken care of. Let's do the hard work.
+        uri = uri.toLowerCase();
+        for (String value : allowed.split(",")) {
+            String protocol = value.trim().toLowerCase();
+
+            if ("all".equals(protocol)) {
+                return false;
+            }
+
+            if (!protocol.endsWith(":")) {
+                protocol += ":";
+            }
+
+            sawHttp = sawHttp || "http:".equals(protocol);
+            sawHttps = sawHttps || "https:".equals(protocol);
+            if (uri.startsWith(protocol)) {
+                return false;
+            }
+        }
+
+        if (mergeHttps) {
+            if (sawHttp && !sawHttps && uri.startsWith("https:")) {
+                return false;
+            }
+            if (sawHttps && !sawHttp && uri.startsWith("http:")) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
The new `ALWAYS_RESOLVE` feature means that the resolver will sometimes access resources on behalf of the caller (ones that were not found in the catalog). That feature failed to take the `ACCESS_EXTERNAL_DOCUMENT` and `ACCESS_EXTERNAL_ENTITY` features into consideration.