### PR TITLE
Remove xml-apis.jar dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ java {
 
 configurations.all {
   resolutionStrategy {
-    force 'xml-apis:xml-apis:1.4.01'
+    exclude group: 'xml-apis', module: 'xml-apis'
   }
 }
 
@@ -36,7 +36,6 @@ dependencies {
   implementation (
     [group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.1.3'],
     [group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.1.3'],
-    [group: 'xml-apis', name: 'xml-apis', version: '1.4.01' ]
   )
 
   compileOnly (
@@ -279,13 +278,19 @@ publishing {
   }
 
   repositories {
-    maven {
-      url = resolverVersion.contains("SNAPSHOT") ?
-        "https://oss.sonatype.org/content/repositories/snapshots/" :
-        "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
-      credentials {
-        username = findProperty("sonatypeUsername") ?: ""
-        password = findProperty("sonatypePassword") ?: ""
+    if (project.findProperty("mavenLocalPublish") != null) {
+      maven {
+        url = project.findProperty("mavenLocalPublish")
+      }
+    } else {
+      maven {
+        url = resolverVersion.contains("SNAPSHOT") ?
+          "https://oss.sonatype.org/content/repositories/snapshots/" :
+          "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+        credentials {
+          username = findProperty("sonatypeUsername") ?: ""
+          password = findProperty("sonatypePassword") ?: ""
+        }
       }
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=5.1.1
+resolverVersion=5.1.2
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/loaders/XmlLoader.java
+++ b/src/main/java/org/xmlresolver/loaders/XmlLoader.java
@@ -107,7 +107,9 @@ public class XmlLoader implements CatalogLoader {
             Resource rsrc = new Resource(catalog);
             InputSource source = new InputSource(rsrc.body());
             source.setSystemId(catalog.toString());
-            return loadCatalog(catalog, source);
+            EntryCatalog entries = loadCatalog(catalog, source);
+            logger.log(AbstractLogger.CONFIG, "Loaded catalog: %s", catalog);
+            return entries;
         } catch (FileNotFoundException fex) {
             logger.log(AbstractLogger.WARNING, "Failed to load catalog: %s: %s", catalog, fex.getMessage());
             catalogMap.put(catalog, new EntryCatalog(config, catalog, null, false));


### PR DESCRIPTION
It appears to be not simply redundant since Java 8 but [actively bad](https://stackoverflow.com/questions/51094274/eclipse-cant-find-xml-related-classes-after-switching-build-path-to-jdk-10/53824670#53824670).

Hat tip to [Olivier Cailloux](https://saxonica.plan.io/issues/5931).