### PR TITLE
Fix same-document references

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=5.1.2
+resolverVersion=5.1.3
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -124,7 +124,12 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
 
             try {
                 URI uri = base == null ? null : new URI(base);
-                uri = uri == null ? new URI(href) : uri.resolve(href);
+                // Don't resolve a same-document reference, that will trim the end off the URI.
+                // The best we can say about a same-document reference is that it refers to whatever
+                // the current base URI is...
+                if (!"".equals(href)) {
+                    uri = uri == null ? new URI(href) : uri.resolve(href);
+                }
                 rsrc = openConnection(uri, false);
             } catch (URISyntaxException | IOException ex) {
                 if (resolver.getConfiguration().getFeature(ResolverFeature.THROW_URI_EXCEPTIONS)) {

--- a/src/test/java/org/xmlresolver/ResolverTest.java
+++ b/src/test/java/org/xmlresolver/ResolverTest.java
@@ -17,6 +17,7 @@ import org.xmlresolver.sources.ResolverInputSource;
 import org.xmlresolver.tools.ResolvingXMLReader;
 import org.xmlresolver.utils.URIUtils;
 
+import javax.xml.transform.Source;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -252,4 +253,36 @@ public class ResolverTest {
             fail(ex.getMessage());
         }
     }
+
+    @Test
+    public void issue140_always_resolve_off() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList());
+        config.setFeature(ResolverFeature.ALWAYS_RESOLVE, false);
+        resolver = new Resolver(config);
+
+        try {
+            String baseURI = URIUtils.cwd().resolve("src/test/resources/xml/ch01.xml").toString();
+            Source result = resolver.resolve("", baseURI);
+            assertNull(result);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void issue140_always_resolve_on() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration(Collections.emptyList());
+        config.setFeature(ResolverFeature.ALWAYS_RESOLVE, true);
+        resolver = new Resolver(config);
+
+        try {
+            String baseURI = URIUtils.cwd().resolve("src/test/resources/xml/ch01.xml").toString();
+            Source result = resolver.resolve("", baseURI);
+            assertTrue(result.getSystemId().endsWith(".xml"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+
 }


### PR DESCRIPTION
When the `ALWAYS_RESOLVE` flag is true, make sure that same-document references (`href=""`) are handled correctly.

Fix #140 
