### PR TITLE
Allow XML Resolver to be run with a restrictive security manager

### DIFF
--- a/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
+++ b/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
@@ -1071,8 +1071,25 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
             // Starting in Java 9, the class loader is no longer a URLClassLoader, so the .getURLs()
             // trick doesn't work. Instead, we're just going to assume that the java.class.path
             // system property is correct. It seems to be.
-            String sep = System.getProperty("path.separator");
-            String cpath = System.getProperty("java.class.path");
+            String sep;
+            String cpath;
+
+            try {
+                sep = System.getProperty("path.separator");
+            } catch (AccessControlException ex) {
+                // I guess you're not allowed to do this...
+                sep = null;
+                resolverLogger.debug("Access forbidden to environment variable: path.separator");
+            }
+
+            try {
+                cpath = System.getProperty("java.class.path");
+            } catch (AccessControlException ex) {
+                // I guess you're not allowed to do this...
+                cpath = null;
+                resolverLogger.debug("Access forbidden to environment variable: java.class.path");
+            }
+
             if (sep != null && cpath != null) {
                 resolverLogger.log(AbstractLogger.CONFIG, "Searching for catalogs on classpath:");
                 for (String loc : cpath.split(sep)) {


### PR DESCRIPTION
This PR traps AccessControlExceptions in the resolver configuration, logs them, and then takes whatever reasonable action it can in the absence of whatever it was trying to do when the exception was raised. This should let the resolver work with more restrictive security managers.

Fix #150 
