### PR TITLE
Catch IllegalArgumentException when minting URIs

### DIFF
--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -131,7 +131,7 @@ public class Resolver implements URIResolver, EntityResolver, EntityResolver2, N
                     uri = uri == null ? new URI(href) : uri.resolve(href);
                 }
                 rsrc = openConnection(uri, false);
-            } catch (URISyntaxException | IOException ex) {
+            } catch (URISyntaxException | IOException | IllegalArgumentException ex) {
                 if (resolver.getConfiguration().getFeature(ResolverFeature.THROW_URI_EXCEPTIONS)) {
                     throw new TransformerException(ex);
                 }


### PR DESCRIPTION
Fix #149 

This was an oversight. I was already catching URISyntaxException and IOException in this case.