### PR TITLE
Move resolver APIs into adapter classes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=6.0.0
+resolverVersion=6.0.1
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/adapters/LSResourceAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/LSResourceAdapter.java
@@ -1,0 +1,67 @@
+package org.xmlresolver.adapters;
+
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
+import org.xmlresolver.*;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
+import org.xmlresolver.sources.ResolverLSInput;
+
+/**
+ * This class implements the {@link LSResourceResolver} API.
+ * <p>It's a separate class in order to avoid a compile-time dependency on the DOM
+ * API for users of {@link XMLResolver} who don't use it.</p>
+ */
+
+public class LSResourceAdapter implements LSResourceResolver {
+    private final XMLResolver resolver;
+    private final ResolverLogger logger;
+
+    public LSResourceAdapter(XMLResolver resolver) {
+        if (resolver == null) {
+            throw new NullPointerException();
+        }
+        this.resolver = resolver;
+        this.logger = resolver.getConfiguration().getFeature(ResolverFeature.RESOLVER_LOGGER);
+    }
+
+    @Override
+    public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
+        if (systemId == null) {
+            return null;
+        }
+
+        final ResourceRequest request;
+        if (type == null || "http://www.w3.org/TR/REC-xml".equals(type)) {
+            logger.log(AbstractLogger.REQUEST, "resolveResource: XML: %s (baseURI: %s, publicId: %s)",
+                    systemId, baseURI, publicId);
+            // This isn't DTD_NATURE because there's no name in this API
+            request = resolver.getRequest(systemId, baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.VALIDATION_PURPOSE);
+            request.setPublicId(publicId);
+        } else {
+            logger.log(AbstractLogger.REQUEST, "resolveResource: %s, %s (namespace: %s, baseURI: %s, publicId: %s)",
+                    type, systemId, namespaceURI, baseURI, publicId);
+
+            String purpose = null;
+            // If it looks like it's going to be used for validation, ...
+            if (ResolverConstants.NATURE_XML_SCHEMA.equals(type)
+                    || ResolverConstants.NATURE_XML_SCHEMA_1_1.equals(type)
+                    || ResolverConstants.NATURE_RELAX_NG.equals(type)) {
+                purpose = ResolverConstants.PURPOSE_SCHEMA_VALIDATION;
+            }
+
+            request = resolver.getRequest(systemId, baseURI, type, purpose);
+            request.setPublicId(publicId);
+        }
+
+        ResourceResponse resp = resolver.resolve(request);
+
+        LSInput input = null;
+        if (resp != null && resp.isResolved()) {
+            input = new ResolverLSInput(resp, publicId);
+        }
+
+        return input;
+
+    }
+}

--- a/src/main/java/org/xmlresolver/adapters/SAXAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/SAXAdapter.java
@@ -1,0 +1,67 @@
+package org.xmlresolver.adapters;
+
+import org.apache.xerces.xni.parser.XMLEntityResolver;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
+import org.xmlresolver.ResolverConstants;
+import org.xmlresolver.ResourceRequest;
+import org.xmlresolver.ResourceResponse;
+import org.xmlresolver.XMLResolver;
+import org.xmlresolver.sources.ResolverInputSource;
+
+import java.io.IOException;
+
+/**
+ * This class implements the {@link EntityResolver} and {@link EntityResolver2} APIs.
+ * <p>It's a separate class in order to avoid a compile-time dependency on the SAX
+ * APIs for users of {@link XMLResolver} who don't use them.</p>
+ */
+
+public class SAXAdapter implements EntityResolver, EntityResolver2 {
+    private final XMLResolver resolver;
+
+    public SAXAdapter(XMLResolver resolver) {
+        if (resolver == null) {
+            throw new NullPointerException();
+        }
+        this.resolver = resolver;
+    }
+
+    @Override
+    public InputSource getExternalSubset(String name, String baseURI) throws SAXException, IOException {
+        ResourceRequest request = resolver.getRequest(null, baseURI, ResolverConstants.DTD_NATURE, ResolverConstants.ANY_PURPOSE);
+        request.setEntityName(name);
+        ResourceResponse resp = resolver.resolve(request);
+
+        ResolverInputSource source = null;
+        if (resp.isResolved()) {
+            source = new ResolverInputSource(resp);
+            source.setSystemId(resp.getURI().toString());
+        }
+
+        return source;
+    }
+
+    @Override
+    public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId) throws SAXException, IOException {
+        ResourceRequest request = resolver.getRequest(systemId, baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+        request.setEntityName(name);
+        request.setPublicId(publicId);
+        ResourceResponse resp = resolver.resolve(request);
+
+        ResolverInputSource source = null;
+        if (resp.isResolved()) {
+            source = new ResolverInputSource(resp);
+            source.setSystemId(resp.getURI().toString());
+        }
+
+        return source;
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+        return resolveEntity(null, publicId, null, systemId);
+    }
+}

--- a/src/main/java/org/xmlresolver/adapters/XercesXniAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/XercesXniAdapter.java
@@ -1,0 +1,176 @@
+package org.xmlresolver.adapters;
+
+import org.apache.xerces.impl.XMLEntityDescription;
+import org.apache.xerces.impl.xs.XSDDescription;
+import org.apache.xerces.util.SAXInputSource;
+import org.apache.xerces.xni.XMLResourceIdentifier;
+import org.apache.xerces.xni.XNIException;
+import org.apache.xerces.xni.grammars.XMLDTDDescription;
+import org.apache.xerces.xni.parser.XMLEntityResolver;
+import org.apache.xerces.xni.parser.XMLInputSource;
+import org.xml.sax.InputSource;
+import org.xmlresolver.*;
+import org.xmlresolver.sources.ResolverInputSource;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * This class implements the {@link XMLEntityResolver} API.
+ * <p>It's a separate class in order to avoid a compile-time dependency on the Xerces
+ * API for users of {@link XMLResolver} who don't use it.</p>
+ */
+
+public class XercesXniAdapter implements XMLEntityResolver {
+    private final XMLResolver resolver;
+
+    public XercesXniAdapter(XMLResolver resolver) {
+        if (resolver == null) {
+            throw new NullPointerException();
+        }
+        this.resolver = resolver;
+    }
+
+    @Override
+    public XMLInputSource resolveEntity(XMLResourceIdentifier resId) throws XNIException, IOException {
+        // Xerces seems to call this API for all resolution. Let's see if we can work out what they're
+        // looking for...
+        if (resId instanceof XMLDTDDescription) {
+            return resolveDTD((XMLDTDDescription) resId);
+        } else if (resId instanceof XMLEntityDescription) {
+            return resolveEntity((XMLEntityDescription) resId);
+        } else if (resId instanceof XSDDescription) {
+            return resolveSchema((XSDDescription) resId);
+        }
+
+        // Well whadda we do now?
+
+        String publicId = resId.getPublicId();
+        String systemId = resId.getLiteralSystemId();
+        String baseURI = resId.getBaseSystemId();
+        String namespace = resId.getNamespace();
+
+        ResourceRequest request = null;
+        ResourceResponse rsrc = null;
+        // If the namespace isn't null, we've gone past the doctype declaration, so it's not an entity.
+        // Otherwise, if publicId or systemId aren't null, try resolving an entity.
+        if (namespace == null) {
+            request = resolver.getRequest(systemId, baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+            request.setPublicId(publicId);
+            rsrc = resolver.resolve(request);
+            if (!rsrc.isResolved()) {
+                request = resolver.getRequest(resId.getExpandedSystemId(), baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+                request.setPublicId(publicId);
+                rsrc = resolver.resolve(request);
+            }
+        }
+
+        if (rsrc == null || !rsrc.isResolved()) {
+            request = resolver.getRequest(namespace, resId.getBaseSystemId(), ResolverConstants.NATURE_XML_SCHEMA, ResolverConstants.PURPOSE_SCHEMA_VALIDATION);
+            rsrc = resolver.resolve(request);
+        }
+
+        if (rsrc == null || !rsrc.isResolved()) {
+            request = resolver.getRequest(systemId, baseURI, ResolverConstants.ANY_NATURE, ResolverConstants.ANY_PURPOSE);
+            request.setResolvingAsEntity(true);
+            rsrc = safeOpenConnection(request);
+        }
+
+        SAXInputSource source = null;
+        if (rsrc != null && rsrc.isResolved()) {
+            source = new SAXInputSource(new ResolverInputSource(rsrc));
+        }
+
+        return source;
+    }
+
+    private ResourceResponse safeOpenConnection(ResourceRequest request) {
+        // This is "safe" in the weird sense that it doesn't throw a checked exception
+        if (resolver.getConfiguration().getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+            try {
+                return ResourceAccess.getResource(request);
+            } catch (URISyntaxException | IOException err) {
+                // What am I supposed to do about this now?
+            }
+        }
+        return null;
+    }
+
+    private XMLInputSource resolveDTD(XMLDTDDescription resId) {
+        ResourceRequest request = resolver.getRequest(resId.getLiteralSystemId(), resId.getBaseSystemId(),
+                ResolverConstants.DTD_NATURE, ResolverConstants.VALIDATION_PURPOSE);
+        request.setEntityName(resId.getRootName());
+        request.setPublicId(resId.getPublicId());
+        ResourceResponse rsrc = resolver.resolve(request);
+        if (!rsrc.isResolved()) {
+            ResourceRequest altRequest;
+            altRequest = resolver.getRequest(resId.getExpandedSystemId(), resId.getBaseSystemId(),
+                    ResolverConstants.DTD_NATURE, ResolverConstants.VALIDATION_PURPOSE);
+            altRequest.setEntityName(resId.getRootName());
+            altRequest.setPublicId(resId.getPublicId());
+            rsrc = resolver.resolve(altRequest);
+        }
+        if (!rsrc.isResolved()) {
+            rsrc = safeOpenConnection(request);
+        }
+        XMLInputSource source = null;
+        if (rsrc != null && rsrc.isResolved()) {
+            source = new SAXInputSource(new ResolverInputSource(rsrc));
+        }
+        return source;
+    }
+
+    private XMLInputSource resolveEntity(XMLEntityDescription resId) {
+        String name = resId.getEntityName();
+        if (name.startsWith("%") || name.startsWith("&")) {
+            // Oh, please. The [expletive]?
+            name = name.substring(1);
+        }
+        ResourceRequest request = resolver.getRequest(resId.getLiteralSystemId(), resId.getBaseSystemId(),
+                ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+        request.setEntityName(name);
+        request.setPublicId(resId.getPublicId());
+        ResourceResponse rsrc = resolver.resolve(request);
+        if (!rsrc.isResolved()) {
+            ResourceRequest altRequest;
+            altRequest = resolver.getRequest(resId.getExpandedSystemId(), resId.getBaseSystemId(),
+                    ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+            altRequest.setEntityName(name);
+            altRequest.setPublicId(resId.getPublicId());
+            rsrc = resolver.resolve(altRequest);
+        }
+        if (rsrc == null) {
+            rsrc = safeOpenConnection(request);
+        }
+        return rsrc == null ? null : new SAXInputSource(new ResolverInputSource(rsrc));
+    }
+
+    private XMLInputSource resolveSchema(XSDDescription resId) {
+        ResourceRequest request = null;
+        ResourceResponse rsrc = null;
+
+        if (resId.getLiteralSystemId() != null) {
+            // If there's a "system identifier" then there's either been a schema location
+            // hint of some sort or this is an xsd:include. Try to resolve the URI.
+            request = resolver.getRequest(resId.getLiteralSystemId(), resId.getBaseSystemId());
+            rsrc = resolver.resolve(request);
+            if (!rsrc.isResolved()) {
+                rsrc = safeOpenConnection(request);
+            }
+        } else {
+            // We don't want to do namespace resolution if there was a hint because
+            // that would take us "back to the top" if some xs:include or xs:import
+            // was 404.
+            request = resolver.getRequest(resId.getNamespace(), resId.getBaseSystemId(), ResolverConstants.NATURE_XML_SCHEMA, ResolverConstants.PURPOSE_SCHEMA_VALIDATION);
+            rsrc = resolver.resolve(request);
+        }
+
+        if (rsrc != null && rsrc.isResolved()) {
+            InputSource source = new ResolverInputSource(rsrc);
+            source.setSystemId(rsrc.getResolvedURI().toString());
+            return new SAXInputSource(source);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/org/xmlresolver/adapters/XmlStreamAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/XmlStreamAdapter.java
@@ -1,0 +1,34 @@
+package org.xmlresolver.adapters;
+
+import org.apache.xerces.xni.parser.XMLEntityResolver;
+import org.xmlresolver.ResolverConstants;
+import org.xmlresolver.ResourceRequest;
+import org.xmlresolver.ResourceResponse;
+import org.xmlresolver.XMLResolver;
+
+import javax.xml.stream.XMLStreamException;
+
+/**
+ * This class implements the {@link javax.xml.stream.XMLResolver} API.
+ * <p>It's a separate class in order to avoid a compile-time dependency on the StAX
+ * API for users of {@link org.xmlresolver.XMLResolver} who don't use it.</p>
+ */
+
+public class XmlStreamAdapter implements javax.xml.stream.XMLResolver {
+    private final org.xmlresolver.XMLResolver resolver;
+
+    public XmlStreamAdapter(org.xmlresolver.XMLResolver resolver) {
+        if (resolver == null) {
+            throw new NullPointerException();
+        }
+        this.resolver = resolver;
+    }
+
+    @Override
+    public Object resolveEntity(String publicID, String systemID, String baseURI, String namespace) throws XMLStreamException {
+        ResourceRequest request = resolver.getRequest(systemID, baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+        request.setPublicId(publicID);
+        ResourceResponse resp = resolver.resolve(request);
+        return resp.getInputStream();
+    }
+}

--- a/src/main/java/org/xmlresolver/adapters/package-info.java
+++ b/src/main/java/org/xmlresolver/adapters/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Implementations of various third-party resolver APIs.
+ * <p>The classes in this package implement APIs for SAX, DOM, StAX, and Xerces XNI resolvers.</p>
+ * <p>They're in separate classes to avoid a compile-time dependency on unused APIs when
+ * instantiating an {@link org.xmlresolver.XMLResolver}</p>
+ */
+
+package org.xmlresolver.adapters;


### PR DESCRIPTION
The 6.0.0 release has a compile-time depenency on every resolver API that it implements. That was accidental.

This PR removes that depenency by adding explicit "adapter" classes. You still need the APIs that you're using at runtime on the classpath, of course.
