### PR TITLE
Bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=6.0.1
+resolverVersion=6.0.2
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/XMLResolver.java
+++ b/src/main/java/org/xmlresolver/XMLResolver.java
@@ -464,7 +464,7 @@ public class XMLResolver {
     }
 
     private ResourceResponse rddlLookup(ResourceResponse lookup) {
-        return rddlLookup(lookup, lookup.getURI());
+        return rddlLookup(lookup, lookup.getResolvedURI());
     }
 
     private ResourceResponse rddlLookup(ResourceResponse lookup, URI resolved) {

--- a/src/test/java/org/xmlresolver/ResourceAccessTest.java
+++ b/src/test/java/org/xmlresolver/ResourceAccessTest.java
@@ -25,6 +25,7 @@ public class ResourceAccessTest {
             ResourceResponse resp = ResourceAccess.getResource(request);
             Assert.assertNotNull(resp);
             Assert.assertTrue(resp.isResolved());
+            Assert.assertNotNull(resp.getInputStream());
             Assert.assertEquals(URIUtils.cwd().resolve(relativeURI), resp.getURI());
             Assert.assertEquals(URIUtils.cwd().resolve(relativeURI), resp.getResolvedURI());
             Assert.assertNotNull(resp.getURI());
@@ -47,6 +48,7 @@ public class ResourceAccessTest {
             ResourceResponse resp = ResourceAccess.getResource(request);
             Assert.assertNotNull(resp);
             Assert.assertTrue(resp.isResolved());
+            Assert.assertNotNull(resp.getInputStream());
             Assert.assertEquals(absURI, resp.getURI());
             Assert.assertEquals(absURI, resp.getResolvedURI());
             Assert.assertNotNull(resp.getURI());
@@ -68,6 +70,7 @@ public class ResourceAccessTest {
             ResourceResponse resp = ResourceAccess.getResource(request);
             Assert.assertNotNull(resp);
             Assert.assertTrue(resp.isResolved());
+            Assert.assertNotNull(resp.getInputStream());
             Assert.assertEquals(URI.create("classpath:org/xmlresolver/schemas/catalog.xml"), resp.getURI());
         } catch (IOException | URISyntaxException ex) {
             fail();
@@ -88,6 +91,7 @@ public class ResourceAccessTest {
             ResourceResponse resp = ResourceAccess.getResource(request);
             Assert.assertNotNull(resp);
             Assert.assertTrue(resp.isResolved());
+            Assert.assertNotNull(resp.getInputStream());
             Assert.assertEquals(URI.create(uri), resp.getURI());
             Assert.assertEquals(URI.create(uri), resp.getResolvedURI());
         } catch (IOException | URISyntaxException ex) {
@@ -106,6 +110,7 @@ public class ResourceAccessTest {
             ResourceResponse resp = ResourceAccess.getResource(request);
             Assert.assertNotNull(resp);
             Assert.assertTrue(resp.isResolved());
+            Assert.assertNotNull(resp.getInputStream());
             Assert.assertEquals(200, resp.getStatusCode());
             Assert.assertEquals(URI.create(uri), resp.getURI());
             Assert.assertEquals("iso-8859-1", resp.getEncoding());
@@ -127,6 +132,7 @@ public class ResourceAccessTest {
             ResourceResponse resp = ResourceAccess.getResource(request);
             Assert.assertNotNull(resp);
             Assert.assertTrue(resp.isResolved());
+            Assert.assertNotNull(resp.getInputStream());
             Assert.assertEquals(200, resp.getStatusCode());
             Assert.assertEquals(URI.create("http://localhost:8222/docs/redirected.txt"), resp.getURI());
             Assert.assertFalse(resp.getHeaders().isEmpty());


### PR DESCRIPTION
1. Support `jar:` URIs; that got lost somewhere by accident
2. Search for RDDL in the *resolved* URI (if the resource was resolved in the catalog)