### PR TITLE
Refactor ResourceResponse; improve handling of masked URIs

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -56,4 +56,4 @@ jobs:
         run: |
           git submodule sync
           git submodule update --init
-          ./gradlew dist
+          ./gradlew --info dist

--- a/build.gradle
+++ b/build.gradle
@@ -2,13 +2,15 @@ plugins {
   id "java"
   id "maven-publish"
   id "signing"
-  id 'com.github.gmazzo.buildconfig' version "3.0.3"
+  id 'com.github.gmazzo.buildconfig' version "5.3.5"
   id 'com.nwalsh.gradle.saxon.saxon-gradle' version '0.9.6'
   id 'com.nwalsh.gradle.docker.container' version '0.0.5'
 }
 
-sourceCompatibility=1.8
-targetCompatibility=1.8
+compileJava {
+  sourceCompatibility = 1.8
+  targetCompatibility = 1.8
+}
 
 repositories {
   mavenLocal()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/xmlresolver/ResourceAccess.java
+++ b/src/main/java/org/xmlresolver/ResourceAccess.java
@@ -66,7 +66,7 @@ public class ResourceAccess {
      * @throws IOException if the resource cannot be accessed.
      */
     public static ResourceResponse getResource(ResourceResponse response) throws URISyntaxException, IOException {
-        URI uri = response.getResolvedURI();
+        URI uri = response.getUnmaskedURI();
         if (uri == null && response.request != null) {
             uri = response.request.getAbsoluteURI();
             if (uri == null && response.request.getURI() != null) {

--- a/src/main/java/org/xmlresolver/ResourceResponse.java
+++ b/src/main/java/org/xmlresolver/ResourceResponse.java
@@ -176,9 +176,25 @@ public class ResourceResponse {
      * redirection at, for example, the HTTP layer, to {@code http://cdn.example.com/version2/some.dtd}, the
      * URI returned by {@link #getResolvedURI()} will be {@code http://cdn.example.com/version2/some.dtd}.
      * See {@link #getURI()}.</p>
+     * <p>If {@link ResolverFeature#MASK_JAR_URIS} is true and the resolved URI is a jar: URI, the
+     * {@link #getURI()} is returned instead.</p>
      * @return The resolved URI.
      */
     public URI getResolvedURI() {
+        if (resolvedURI.getScheme().equals("jar") && request.config.getFeature(ResolverFeature.MASK_JAR_URIS)) {
+            return uri;
+        }
+        return resolvedURI;
+    }
+
+    /**
+     * Get the resolved URI, irrespective of masking.
+     * <p>Where {@link #getResolvedURI()} will not return a {@code jar:} URI if the
+     * {@link ResolverFeature#MASK_JAR_URIS} is true, this method always returns the actual, unmasked URI.
+     * </p>
+     * @return The resolved URI, unmasked.
+     */
+    public URI getUnmaskedURI() {
         return resolvedURI;
     }
 

--- a/src/main/java/org/xmlresolver/adapters/SAXAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/SAXAdapter.java
@@ -38,7 +38,7 @@ public class SAXAdapter implements EntityResolver, EntityResolver2 {
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getURI().toString());
+            source.setSystemId(resp.getResolvedURI().toString());
         }
 
         return source;
@@ -54,7 +54,7 @@ public class SAXAdapter implements EntityResolver, EntityResolver2 {
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getURI().toString());
+            source.setSystemId(resp.getResolvedURI().toString());
         }
 
         return source;

--- a/src/main/java/org/xmlresolver/sources/ResolverInputSource.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverInputSource.java
@@ -14,23 +14,10 @@ import java.util.Map;
  *
  */
 public class ResolverInputSource extends InputSource implements ResolverResourceInfo {
-    /** The underlying, resolved URI. */
-    public final URI resolvedURI;
+    private ResourceResponse response;
+    private final URI resolvedURI;
     private final int statusCode;
     private final Map<String,List<String>> resolvedHeaders;
-
-    /** Construct the {@link org.xml.sax.InputSource} while preserving the local URI.
-     *
-     * @param localURI The local URI.
-     * @param stream The stream to return for this source.
-     * */
-    public ResolverInputSource(URI localURI, InputStream stream) {
-        super(stream);
-        setSystemId(localURI.toString());
-        this.resolvedURI = localURI;
-        this.statusCode = 200;
-        this.resolvedHeaders = Collections.emptyMap();
-    }
 
     /** Construct the @link org.xml.sax.InputSource} directly from a ResolvedResource
      *
@@ -40,23 +27,33 @@ public class ResolverInputSource extends InputSource implements ResolverResource
         super(rsrc.getInputStream());
         setSystemId(rsrc.getURI().toString());
         setPublicId(rsrc.request.getPublicId());
+        this.response = rsrc;
         resolvedURI = rsrc.getResolvedURI();
         statusCode = rsrc.getStatusCode();
         resolvedHeaders = rsrc.getHeaders();
     }
 
+    @Override
+    public ResourceResponse getResponse() {
+        return response;
+    }
+
+    @Override
     public URI getResolvedURI() {
         return resolvedURI;
     }
 
+    @Override
     public int getStatusCode() {
         return statusCode;
     }
 
+    @Override
     public Map<String, List<String>> getHeaders() {
         return resolvedHeaders;
     }
 
+    @Override
     public String getHeader(String headerName) {
         return RsrcUtils.getHeader(headerName, resolvedHeaders);
     }

--- a/src/main/java/org/xmlresolver/sources/ResolverLSInput.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverLSInput.java
@@ -16,8 +16,8 @@ import java.util.Map;
  *
  */
 public class ResolverLSInput implements LSInput, ResolverResourceInfo {
-    /** The underlying, resolved URI. */
-    public final URI resolvedURI;
+    private final ResourceResponse response;
+    private final URI resolvedURI;
     final String publicId;
     final String systemId;
     final InputStream body;
@@ -35,8 +35,9 @@ public class ResolverLSInput implements LSInput, ResolverResourceInfo {
      * */
     public ResolverLSInput(ResourceResponse resp, String publicId) {
         resolvedURI = resp.getResolvedURI();
+        this.response = resp;
         this.body = resp.getInputStream();
-        this.systemId = resp.getURI().toString();
+        this.systemId = resp.getResolvedURI().toString();
         this.publicId = publicId;
         this.uri = resp.getURI();
         this.statusCode = resp.getStatusCode();
@@ -148,18 +149,27 @@ public class ResolverLSInput implements LSInput, ResolverResourceInfo {
         throw new UnsupportedOperationException("Can't set certified text on resolver LSInput");
     }
 
+    @Override
+    public ResourceResponse getResponse() {
+        return response;
+    }
+
+    @Override
     public URI getResolvedURI() {
         return resolvedURI;
     }
 
+    @Override
     public int getStatusCode() {
         return statusCode;
     }
 
+    @Override
     public Map<String, List<String>> getHeaders() {
         return resolvedHeaders;
     }
 
+    @Override
     public String getHeader(String headerName) {
         return RsrcUtils.getHeader(headerName, resolvedHeaders);
     }

--- a/src/main/java/org/xmlresolver/sources/ResolverResourceInfo.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverResourceInfo.java
@@ -1,5 +1,7 @@
 package org.xmlresolver.sources;
 
+import org.xmlresolver.ResourceResponse;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +13,12 @@ import java.util.Map;
  * and headers may also be available.</p>
  */
 public interface ResolverResourceInfo {
+    /** Returns the underlying resolver response.
+     *
+     * @return The response.
+     */
+    ResourceResponse getResponse();
+
     /** Returns the resolved URI associated with the request.
      *
      * @return the resolved URI.

--- a/src/main/java/org/xmlresolver/sources/ResolverSAXSource.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverSAXSource.java
@@ -12,42 +12,40 @@ import java.util.Map;
 
 /** A {@link javax.xml.transform.sax.SAXSource} with a <code>resolvedURI</code>. */
 public class ResolverSAXSource extends SAXSource implements ResolverResourceInfo {
-    /** The underlying, resolved URI. */
-    public final URI resolvedURI;
+    private final ResourceResponse response;
+    private final URI resolvedURI;
     private final int statusCode;
     private final Map<String, List<String>> resolvedHeaders;
 
-    /** Construct a {@link javax.xml.transform.sax.SAXSource} while preserving the local URI.
-     *
-     * @param localURI The local URI.
-     * @param source The input source to return for this source.
-     * */
-    public ResolverSAXSource(URI localURI, InputSource source) {
-        super(source);
-        resolvedURI = localURI;
-        statusCode = 200;
-        resolvedHeaders = Collections.emptyMap();
-    }
-
     public ResolverSAXSource(ResourceResponse resp) {
         super(new InputSource(resp.getInputStream()));
+        this.response = resp;
         resolvedURI = resp.getResolvedURI();
         statusCode = resp.getStatusCode();
         resolvedHeaders = resp.getHeaders();
     }
 
+    @Override
+    public ResourceResponse getResponse() {
+        return response;
+    }
+
+    @Override
     public URI getResolvedURI() {
         return resolvedURI;
     }
 
+    @Override
     public int getStatusCode() {
         return statusCode;
     }
 
+    @Override
     public Map<String, List<String>> getHeaders() {
         return resolvedHeaders;
     }
 
+    @Override
     public String getHeader(String headerName) {
         return RsrcUtils.getHeader(headerName, resolvedHeaders);
     }

--- a/src/test/java/org/xmlresolver/ArchivedCatalogTest.java
+++ b/src/test/java/org/xmlresolver/ArchivedCatalogTest.java
@@ -32,7 +32,7 @@ public class ArchivedCatalogTest {
             InputSource source = resolver.getEntityResolver().resolveEntity(null, "https://xmlresolver.org/ns/zipped/sample.dtd");
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertTrue(rsource.resolvedURI.toString().startsWith("jar:file:"));
+            assertTrue(rsource.getResolvedURI().toString().startsWith("jar:file:"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -66,7 +66,7 @@ public class ArchivedCatalogTest {
             InputSource source = resolver.getEntityResolver().resolveEntity(null, "https://xmlresolver.org/ns/zipped/sample.dtd");
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertTrue(rsource.resolvedURI.toString().startsWith("jar:file:"));
+            assertTrue(rsource.getResolvedURI().toString().startsWith("jar:file:"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -83,7 +83,7 @@ public class ArchivedCatalogTest {
             InputSource source = resolver.getEntityResolver().resolveEntity(null, "https://xmlresolver.org/ns/zipped/sample.dtd");
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertTrue(rsource.resolvedURI.toString().startsWith("jar:file:"));
+            assertTrue(rsource.getResponse().getUnmaskedURI().toString().startsWith("jar:file:"));
             assertEquals("https://xmlresolver.org/ns/zipped/sample.dtd", rsource.getSystemId());
         } catch (IOException | SAXException ex) {
             fail();
@@ -102,7 +102,7 @@ public class ArchivedCatalogTest {
             InputSource source = resolver.getEntityResolver().resolveEntity(null, "https://xmlresolver.org/ns/zipped/sample.dtd");
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertTrue(rsource.resolvedURI.toString().startsWith("jar:file:"));
+            assertTrue(rsource.getResolvedURI().toString().startsWith("jar:file:"));
             assertTrue(rsource.getSystemId().startsWith("jar:file:"));
         } catch (IOException | SAXException ex) {
             fail();

--- a/src/test/java/org/xmlresolver/CatalogSpacesTest.java
+++ b/src/test/java/org/xmlresolver/CatalogSpacesTest.java
@@ -36,7 +36,7 @@ public class CatalogSpacesTest {
             InputSource is = resolver.getEntityResolver().resolveEntity(null, "https://xmlresolver.org/ns/sample/sample.dtd");
             assertNotNull(is);
             ResolverInputSource ris = (ResolverInputSource) is;
-            assertTrue(ris.resolvedURI.toString().contains("/Sample%2010/"));
+            assertTrue(ris.getResolvedURI().toString().contains("/Sample%2010/"));
         } catch (Exception ex) {
             fail();
         }

--- a/src/test/java/org/xmlresolver/DataTest.java
+++ b/src/test/java/org/xmlresolver/DataTest.java
@@ -271,12 +271,6 @@ public class DataTest {
     }
 
     @Test
-    public void gen_lookupPublicd1e83() {
-        URI result = manager.lookupPublic(null, "datatypes");
-        assertNotNull(result);
-    }
-
-    @Test
     public void gen_lookupSystemd1e84() {
         URI result = manager.lookupSystem("https://www.w3.org/2001/datatypes.dtd");
         assertNotNull(result);

--- a/src/test/java/org/xmlresolver/RddlTest.java
+++ b/src/test/java/org/xmlresolver/RddlTest.java
@@ -132,7 +132,7 @@ public class RddlTest {
                 "http://www.rddl.org/purposes#validation");
         ResourceResponse xsd = resolver.resolve(req);
         assertTrue(xsd.isResolved());
-        assertTrue(xsd.getResolvedURI().toString().endsWith("/xml.xsd"));
+        assertTrue(xsd.getUnmaskedURI().toString().endsWith("/xml.xsd"));
     }
 }
 

--- a/src/test/java/org/xmlresolver/ResolverTest.java
+++ b/src/test/java/org/xmlresolver/ResolverTest.java
@@ -52,7 +52,7 @@ public class ResolverTest {
             assertTrue(source.getSystemId().endsWith(result.getPath()));
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertEquals(rsource.resolvedURI, result);
+            assertEquals(rsource.getResolvedURI(), result);
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -66,7 +66,7 @@ public class ResolverTest {
             assertTrue(source.getSystemId().endsWith(result.getPath()));
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertEquals(rsource.resolvedURI, result);
+            assertEquals(rsource.getResolvedURI(), result);
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -201,7 +201,7 @@ public class ResolverTest {
             assertTrue(source.getSystemId().endsWith(result.getPath()));
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertEquals(rsource.resolvedURI, result);
+            assertEquals(rsource.getResolvedURI(), result);
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -233,7 +233,7 @@ public class ResolverTest {
             assertTrue(source.getSystemId().endsWith(result.getPath()));
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertEquals(rsource.resolvedURI, result);
+            assertEquals(rsource.getResolvedURI(), result);
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -256,7 +256,7 @@ public class ResolverTest {
             assertTrue(source.getSystemId().endsWith(result.getPath()));
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertEquals(rsource.resolvedURI, result);
+            assertEquals(rsource.getResolvedURI(), result);
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/src/test/java/org/xmlresolver/ResolverTestJar.java
+++ b/src/test/java/org/xmlresolver/ResolverTestJar.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xmlresolver.sources.ResolverInputSource;
+import org.xmlresolver.sources.ResolverSAXSource;
 import org.xmlresolver.utils.URIUtils;
 
 import java.io.IOException;
@@ -43,6 +44,9 @@ public class ResolverTestJar {
         String systemId = "https://xmlresolver.org/ns/sample/sample.dtd";
 
         try {
+            System.err.println("WAT?");
+
+
             config.setFeature(ResolverFeature.MASK_JAR_URIS, true);
             URI result = URIUtils.cwd().resolve("src/test/resources/sample10/sample.dtd");
             InputSource source = resolver.getEntityResolver().resolveEntity(null, systemId);
@@ -56,6 +60,9 @@ public class ResolverTestJar {
 
             config.setFeature(ResolverFeature.MASK_JAR_URIS, false);
             source = resolver.getEntityResolver().resolveEntity(null, systemId);
+
+            System.err.println("S: " + source.getSystemId());
+
             assertTrue(source.getSystemId().startsWith("jar:file:"));
             assertNotNull(source.getByteStream());
             rsource = ((ResolverInputSource) source);

--- a/src/test/java/org/xmlresolver/ResolverTestJar.java
+++ b/src/test/java/org/xmlresolver/ResolverTestJar.java
@@ -49,17 +49,18 @@ public class ResolverTestJar {
             assertEquals(systemId, source.getSystemId());
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertEquals("jar", rsource.resolvedURI.getScheme());
-            assertTrue(rsource.resolvedURI.getSchemeSpecificPart().startsWith("file:"));
+
+            URI actualURI = rsource.getResponse().getUnmaskedURI();
+            assertEquals("jar",actualURI.getScheme());
+            assertTrue(actualURI.getSchemeSpecificPart().startsWith("file:"));
 
             config.setFeature(ResolverFeature.MASK_JAR_URIS, false);
-            result = URIUtils.cwd().resolve("src/test/resources/sample10/sample.dtd");
             source = resolver.getEntityResolver().resolveEntity(null, systemId);
             assertTrue(source.getSystemId().startsWith("jar:file:"));
             assertNotNull(source.getByteStream());
             rsource = ((ResolverInputSource) source);
-            assertEquals("jar", rsource.resolvedURI.getScheme());
-            assertTrue(rsource.resolvedURI.getSchemeSpecificPart().startsWith("file:"));
+            assertEquals("jar", rsource.getResolvedURI().getScheme());
+            assertTrue(rsource.getResolvedURI().getSchemeSpecificPart().startsWith("file:"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -72,8 +73,10 @@ public class ResolverTestJar {
             assertTrue(source.getSystemId().endsWith("/sample/uri.dtd"));
             assertNotNull(source.getByteStream());
             ResolverInputSource rsource = ((ResolverInputSource) source);
-            assertTrue(rsource.resolvedURI.toString().startsWith("jar:file:/"));
-            assertTrue(rsource.resolvedURI.toString().endsWith("data3.jar!/data/sample.dtd"));
+
+            String actualURI = rsource.getResponse().getUnmaskedURI().toString();
+            assertTrue(actualURI.startsWith("jar:file:/"));
+            assertTrue(actualURI.endsWith("data3.jar!/data/sample.dtd"));
         } catch (IOException | SAXException ex) {
             fail();
         }


### PR DESCRIPTION
There were still some issues around masked URIs. They're now handled in `getResolvedURI()`. Added a new method, `getUnmaskedURI()` to get the real, unmasked URI. Updated a number of tests to take advantage of this.