### PR TITLE
Add backwards-compatible APIs, fix a few bugs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,11 @@
 basename=xmlresolver
 
-resolverVersion=6.0.2
+# ************************************************
+# When this version number changes:
+resolverVersion=6.0.3
+# Also change the version number in overview.html
+# FIXME: figure out how to automate this.
+# ************************************************
 
 group=org.xmlresolver
 

--- a/src/main/java/org/xmlresolver/CatalogResolver.java
+++ b/src/main/java/org/xmlresolver/CatalogResolver.java
@@ -1,0 +1,69 @@
+package org.xmlresolver;
+
+import org.xmlresolver.logging.ResolverLogger;
+
+/**
+ * This class is a shim that provides a degree of compatibility with XML Resolver 5.0.
+ * @deprecated 6.0.0
+ */
+public class CatalogResolver {
+    private final ResolverLogger logger;
+    private final XMLResolverConfiguration config;
+    private final XMLResolver resolver;
+
+    public CatalogResolver() {
+        this(new XMLResolverConfiguration());
+    }
+
+    public CatalogResolver(XMLResolverConfiguration config) {
+        this.config = config;
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        resolver = new XMLResolver(config);
+    }
+
+    public XMLResolverConfiguration getConfiguration() {
+        return config;
+    }
+
+    public ResolvedResource resolveURI(String href, String baseURI) {
+        System.err.println("CR resolveURI " + href);
+        ResourceRequest req = resolver.getRequest(href, baseURI);
+        ResourceResponse resp = resolver.resolve(req);
+        System.err.println("RR: " + resp.getURI());
+
+        if (resp.isResolved()) {
+            return new ResolvedResource(resp);
+        }
+        return null;
+    }
+
+    public ResolvedResource resolveEntity(String name, String publicId, String systemId, String baseURI) {
+        ResourceRequest req = resolver.getRequest(systemId, baseURI);
+        req.setEntityName(name);
+        req.setPublicId(publicId);
+        ResourceResponse resp = resolver.resolve(req);
+        if (resp.isResolved()) {
+            return new ResolvedResource(resp);
+        }
+        return null;
+    }
+
+    public ResolvedResource resolveDoctype(String name, String baseURI) {
+        ResourceRequest req = resolver.getRequest(baseURI, ResolverConstants.DTD_NATURE, ResolverConstants.ANY_PURPOSE);
+        req.setEntityName(name);
+        ResourceResponse resp = resolver.resolve(req);
+        if (resp.isResolved()) {
+            return new ResolvedResource(resp);
+        }
+        return null;
+    }
+
+    public ResolvedResource resolveNamespace(String uri, String baseURI, String nature, String purpose) {
+        ResourceRequest req = resolver.getRequest(uri, baseURI, nature, purpose);
+        ResourceResponse resp = resolver.resolve(req);
+        if (resp.isResolved()) {
+            return new ResolvedResource(resp);
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/xmlresolver/ResolvedResource.java
+++ b/src/main/java/org/xmlresolver/ResolvedResource.java
@@ -1,0 +1,42 @@
+package org.xmlresolver;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class is a shim that provides a degree of compatibility with XML Resolver 5.0.
+ * @deprecated 6.0.0
+ */
+public class ResolvedResource {
+    private final ResourceResponse response;
+
+    public ResolvedResource(ResourceResponse response) {
+        this.response = response;
+    }
+
+    public URI getResolvedURI() {
+        return response.getResolvedURI();
+    }
+
+    public URI getLocalURI() {
+        return response.getUnmaskedURI();
+    }
+
+    public InputStream getInputStream() {
+        return response.getInputStream();
+    }
+
+    public String getContentType() {
+        return response.getContentType();
+    }
+
+    public int getStatusCode() {
+        return response.getStatusCode();
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return response.getHeaders();
+    }
+}

--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -1,0 +1,165 @@
+package org.xmlresolver;
+
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
+import org.xmlresolver.logging.AbstractLogger;
+import org.xmlresolver.logging.ResolverLogger;
+import org.xmlresolver.sources.ResolverInputSource;
+import org.xmlresolver.sources.ResolverLSInput;
+import org.xmlresolver.sources.ResolverSAXSource;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.URIResolver;
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * This class is a shim that provides a degree of compatibility with XML Resolver 5.0.
+ * <p>Some applications create a resolver using reflection on {@code org.xmlresolver.Resolver}
+ * to call the zero-argument constructor. This class is an attempt to provide that API.</p>
+ * @deprecated 6.0.0
+ */
+public class Resolver implements URIResolver, LSResourceResolver, EntityResolver, EntityResolver2 {
+    public static final String PURPOSE_SCHEMA_VALIDATION = "http://www.rddl.org/purposes#schema-validation";
+    public static final String NATURE_XML_SCHEMA = "http://www.w3.org/2001/XMLSchema";
+    public static final String NATURE_XML_SCHEMA_1_1 = "http://www.w3.org/2001/XMLSchema/v1.1";
+    public static final String NATURE_RELAX_NG = "http://relaxng.org/ns/structure/1.0";
+
+    private final ResolverLogger logger;
+    protected final XMLResolverConfiguration config;
+    protected final XMLResolver resolver;
+    protected CatalogResolver catalogResolver = null;
+
+    public Resolver() {
+        this(new XMLResolverConfiguration());
+    }
+
+    public Resolver(XMLResolverConfiguration config) {
+        this.config = config;
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        resolver = new XMLResolver(config);
+    }
+
+    public Resolver(CatalogResolver resolver) {
+        config = resolver.getConfiguration();
+        logger = config.getFeature(ResolverFeature.RESOLVER_LOGGER);
+        this.resolver = new XMLResolver(config);
+    }
+
+    public static String version() {
+        return BuildConfig.VERSION;
+    }
+
+    public XMLResolverConfiguration getConfiguration() {
+        return config;
+    }
+
+    public CatalogResolver getCatalogResolver() {
+        if (catalogResolver == null) {
+            catalogResolver = new CatalogResolver(config);
+        }
+        return catalogResolver;
+    }
+
+    @Override
+    public Source resolve(String href, String base) throws TransformerException {
+        ResourceRequest req = resolver.getRequest(href, base);
+        ResourceResponse resp = resolver.resolve(req);
+
+        if (!resp.isResolved()) {
+            if (!config.getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+                return null;
+            }
+            try {
+                resp = ResourceAccess.getResource(req);
+            } catch (URISyntaxException | IOException | IllegalArgumentException ex) {
+                if (resolver.getConfiguration().getFeature(ResolverFeature.THROW_URI_EXCEPTIONS)) {
+                    throw new TransformerException(ex);
+                }
+                return null;
+            }
+        }
+
+        if (resp.isResolved()) {
+            ResolverSAXSource source = new ResolverSAXSource(resp);
+            source.setSystemId(resp.getResolvedURI().toString());
+            return source;
+        }
+
+        return null;
+    }
+
+    @Override
+    public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
+        ResourceRequest req = null;
+        if (type == null || "http://www.w3.org/TR/REC-xml".equals(type)) {
+            logger.log(AbstractLogger.REQUEST, "resolveResource: XML: %s (baseURI: %s, publicId: %s)",
+                    systemId, baseURI, publicId);
+            req = resolver.getRequest(systemId, baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+            req.setPublicId(publicId);
+        } else {
+            logger.log(AbstractLogger.REQUEST, "resolveResource: %s, %s (namespace: %s, baseURI: %s, publicId: %s)",
+                    type, systemId, namespaceURI, baseURI, publicId);
+
+            String purpose = null;
+            // If it looks like it's going to be used for validation, ...
+            if (NATURE_XML_SCHEMA.equals(type)
+                    || NATURE_XML_SCHEMA_1_1.equals(type)
+                    || NATURE_RELAX_NG.equals(type)) {
+                purpose = PURPOSE_SCHEMA_VALIDATION;
+            }
+
+            if (systemId != null) {
+                req = resolver.getRequest(systemId, baseURI, type, purpose);
+            }
+        }
+
+        if (req != null) {
+            ResourceResponse resp = resolver.resolve(req);
+            if (resp.isResolved()) {
+                return new ResolverLSInput(resp, publicId);
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public InputSource getExternalSubset(String name, String baseURI) throws SAXException, IOException {
+        ResourceRequest req = resolver.getRequest(baseURI, null, ResolverConstants.ANY_NATURE, ResolverConstants.ANY_PURPOSE);
+        req.setEntityName(name);
+        ResourceResponse resp = resolver.resolve(req);
+        if (resp.isResolved()) {
+            ResolverInputSource source = new ResolverInputSource(resp);
+            source.setSystemId(resp.getResolvedURI().toString());
+            return source;
+        }
+
+        return null;
+    }
+
+    @Override
+    public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId) throws SAXException, IOException {
+        ResourceRequest req = resolver.getRequest(systemId, baseURI, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+        req.setEntityName(name);
+        req.setPublicId(publicId);
+        ResourceResponse resp = resolver.resolve(req);
+        if (resp.isResolved()) {
+            ResolverInputSource source = new ResolverInputSource(resp);
+            source.setSystemId(resp.getResolvedURI().toString());
+            return source;
+        }
+
+        return null;
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+        return resolveEntity(null, publicId, null, systemId);
+    }
+}

--- a/src/main/java/org/xmlresolver/ResourceAccess.java
+++ b/src/main/java/org/xmlresolver/ResourceAccess.java
@@ -90,7 +90,7 @@ public class ResourceAccess {
             case "jar":
                 return getJarResource(response.request, uri);
             default:
-                // If it's not data: or classpath:, let's hope Java's URLConnection class will read it...
+                // If it's not data:, classpath:, or jar:, let's hope Java's URLConnection class will read it...
                 return getNetResource(response.request, uri);
         }
     }

--- a/src/main/java/org/xmlresolver/ResourceResponse.java
+++ b/src/main/java/org/xmlresolver/ResourceResponse.java
@@ -65,7 +65,8 @@ public class ResourceResponse {
         this.resolved = false;
 
         if (uri != null) {
-            if ("jar".equals(uri.getScheme()) && request.config.getFeature(ResolverFeature.MASK_JAR_URIS)) {
+            if (("jar".equals(uri.getScheme()) || "classpath".equals(uri.getScheme()))
+                    && request.config.getFeature(ResolverFeature.MASK_JAR_URIS)) {
                 try {
                     this.uri = request.getAbsoluteURI();
                 } catch (URISyntaxException ex) {
@@ -181,7 +182,8 @@ public class ResourceResponse {
      * @return The resolved URI.
      */
     public URI getResolvedURI() {
-        if (resolvedURI.getScheme().equals("jar") && request.config.getFeature(ResolverFeature.MASK_JAR_URIS)) {
+        if ((resolvedURI.getScheme().equals("jar") || resolvedURI.getScheme().equals("classpath"))
+                && request.config.getFeature(ResolverFeature.MASK_JAR_URIS)) {
             return uri;
         }
         return resolvedURI;

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -6,6 +6,8 @@ designed to work in the context of XML processes, resolving external
 identifiers for parsers and URIs for other processes (XML Schema
 validation, RELAX NG validation, transformations, querying etc.).</p>
 
+<p>This JavaDoc is for the version 6.0.3 API.</p>
+
 <p>By providing <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">an OASIS XML Catalog</a> file that maps URIs, for example,
 from web resources to local resources, you can improve the performance
 of your processes and remove dependence on external web servers.</p>

--- a/src/test/java/org/xmlresolver/ResourceAccessTest.java
+++ b/src/test/java/org/xmlresolver/ResourceAccessTest.java
@@ -61,6 +61,9 @@ public class ResourceAccessTest {
     public void testClasspathAccess() {
         try {
             XMLResolverConfiguration config = new XMLResolverConfiguration();
+            // If jar (and classpath) URIs are masked, I get back the original classpath URI
+            // that's not what's being tested here.
+            config.setFeature(ResolverFeature.MASK_JAR_URIS, false);
             ResourceRequest request = new ResourceRequest(config);
 
             // n.b., leading "/" is not how classpath: URIs should be constructed


### PR DESCRIPTION
I discovered that removing all the V5.x APIs is, uh, inconvenient. I've added some deprecated classes that implement (some of) those APIs in terms of the new APIs. It's possible that this will need a little refinement as testing continues.

I fixed a bug where `jar:` URIs were masked but `classpath:` URIs were not. Those have the same drawbacks.

Fix #168 
Fix #169 
