### PR TITLE
Correct getNetResource so it uses the resourceURI

### DIFF
--- a/src/test/java/org/xmlresolver/Jaxp185Test.java
+++ b/src/test/java/org/xmlresolver/Jaxp185Test.java
@@ -222,7 +222,23 @@ public class Jaxp185Test {
         }
     }
 
-// yyy
+    @Test
+    public void lookupPublicId() throws IOException, SAXException {
+        InputSource source = unrestrictedResolver.getEntityResolver().resolveEntity("-//Sample//DTD Sample 1.0//EN", null);
+        assertNotNull(source);
+    }
+
+    @Test
+    public void lookupPublicIdBadURI() throws IOException, SAXException {
+        InputSource source = unrestrictedResolver.getEntityResolver().resolveEntity("-//Sample//DTD Sample 1.0//EN", "relativeLocation.dtd");
+        assertNotNull(source);
+    }
+
+    @Test
+    public void lookupPublicIdOkURI() throws IOException, SAXException {
+        InputSource source = unrestrictedResolver.getEntityResolver().resolveEntity("-//Sample//DTD Sample 1.0//EN", "http://localhost:8222/docs/sample/sample.dtd");
+        assertNotNull(source);
+    }
 
     @Test
     public void lookupUriMergedPassHttpsAbs() {


### PR DESCRIPTION
Close #177 

This is an alternate fix for 177. The `getNetResource` method should aways attempt to resolve the `resourceURI`. That's the URI returned by the resolver. In many cases, that's also in the request, but it doesn't have to be.

Thanks to @jarl-dk for the test and a proposed fix.