### PR TITLE
Separate EntityResolver and EntityResolver2 implementations

### DIFF
--- a/src/main/java/org/xmlresolver/XMLResolver.java
+++ b/src/main/java/org/xmlresolver/XMLResolver.java
@@ -4,10 +4,7 @@ import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-import org.xmlresolver.adapters.SAXAdapter;
-import org.xmlresolver.adapters.LSResourceAdapter;
-import org.xmlresolver.adapters.XercesXniAdapter;
-import org.xmlresolver.adapters.XmlStreamAdapter;
+import org.xmlresolver.adapters.*;
 import org.xmlresolver.logging.AbstractLogger;
 import org.xmlresolver.logging.ResolverLogger;
 import org.xmlresolver.sources.ResolverSAXSource;
@@ -542,19 +539,19 @@ public class XMLResolver {
     }
 
     /**
-     * Get a {@link SAXAdapter}.
+     * Get a {@link SAX1Adapter}.
      * @return An entity resolver.
      */
-    public SAXAdapter getEntityResolver() {
-        return getEntityResolver2();
+    public SAX1Adapter getEntityResolver() {
+        return new SAX1Adapter(this);
     }
 
     /**
-     * Get a {@link SAXAdapter}.
+     * Get a {@link SAX2Adapter}.
      * @return An entity resolver.
      */
-    public SAXAdapter getEntityResolver2() {
-        return new SAXAdapter(this);
+    public SAX2Adapter getEntityResolver2() {
+        return new SAX2Adapter(this);
     }
 
     /**

--- a/src/main/java/org/xmlresolver/adapters/SAX1Adapter.java
+++ b/src/main/java/org/xmlresolver/adapters/SAX1Adapter.java
@@ -1,0 +1,47 @@
+package org.xmlresolver.adapters;
+
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
+import org.xmlresolver.ResolverConstants;
+import org.xmlresolver.ResourceRequest;
+import org.xmlresolver.ResourceResponse;
+import org.xmlresolver.XMLResolver;
+import org.xmlresolver.sources.ResolverInputSource;
+
+import java.io.IOException;
+
+/**
+ * This class implements the {@link EntityResolver} API.
+ * <p>It's a separate class in order to avoid a compile-time dependency on the SAX
+ * APIs for users of {@link XMLResolver} who don't use them. It's separate from the
+ * implementation of {@link EntityResolver2} so that the caller has control over
+ * the API used.</p>
+ */
+
+public class SAX1Adapter implements EntityResolver {
+    private final XMLResolver resolver;
+
+    public SAX1Adapter(XMLResolver resolver) {
+        if (resolver == null) {
+            throw new NullPointerException();
+        }
+        this.resolver = resolver;
+    }
+
+    @Override
+    public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+        ResourceRequest request = resolver.getRequest(systemId, null, ResolverConstants.EXTERNAL_ENTITY_NATURE, ResolverConstants.ANY_PURPOSE);
+        request.setPublicId(publicId);
+        ResourceResponse resp = resolver.resolve(request);
+
+        ResolverInputSource source = null;
+        if (resp.isResolved()) {
+            source = new ResolverInputSource(resp);
+            source.setSystemId(resp.getResolvedURI().toString());
+        }
+
+        return source;
+    }
+}

--- a/src/test/java/org/xmlresolver/SAXResolverTest.java
+++ b/src/test/java/org/xmlresolver/SAXResolverTest.java
@@ -1,0 +1,56 @@
+package org.xmlresolver;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.XMLReader;
+
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.util.ArrayList;
+
+import static org.junit.Assert.fail;
+
+public class SAXResolverTest {
+    @Test
+    public void issue183_sax1() {
+        try {
+            XMLResolverConfiguration resolverConfig = new XMLResolverConfiguration();
+            resolverConfig.setFeature(ResolverFeature.ALWAYS_RESOLVE, true);
+            XMLResolver resolver = new XMLResolver(resolverConfig);
+
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser parser = spf.newSAXParser();
+            XMLReader reader = parser.getXMLReader();
+
+            // This is the SAX1 API so won't have the EntityResolver2 APIs.
+            reader.setEntityResolver(resolver.getEntityResolver());
+
+            // Doesn't matter what we parse.
+            reader.parse(new InputSource("src/test/resources/empty.xml"));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void issue183_sax2() {
+        try {
+            XMLResolverConfiguration resolverConfig = new XMLResolverConfiguration();
+            resolverConfig.setFeature(ResolverFeature.ALWAYS_RESOLVE, true);
+            XMLResolver resolver = new XMLResolver(resolverConfig);
+
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser parser = spf.newSAXParser();
+            XMLReader reader = parser.getXMLReader();
+            reader.setEntityResolver(resolver.getEntityResolver2());
+
+            // Doesn't matter what we parse.
+            reader.parse(new InputSource("src/test/resources/empty.xml"));
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
+}


### PR DESCRIPTION
Fix #183 

1. I split the `SAXAdapter` into `SAX1Adapter` and `SAX2Adapter` so that you can have an `EntityResolver` that is distinct from `EntityResolver2`
2. The behavior of `getExternalSubset` was incoherent. I've changed it so it'll return `null` (irrespective of `ALWAYS_RESOLVE`) if it would have returned the source document. That *can't* be the external subset.
