### PR TITLE
Windows UNC tests (and bug fix)

### DIFF
--- a/src/test/java/org/xmlresolver/WindowsTests.java
+++ b/src/test/java/org/xmlresolver/WindowsTests.java
@@ -1,0 +1,53 @@
+package org.xmlresolver;
+
+import org.junit.jupiter.api.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xmlresolver.tools.ResolvingXMLReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class WindowsTests {
+    @Test
+    public void parseWithoutCatalog() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        config.setFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS, true);
+
+        XMLResolver resolver = new XMLResolver(config);
+
+        ResolvingXMLReader reader = new ResolvingXMLReader(resolver);
+        InputSource source = new InputSource("src/test/resources/windows.xml");
+        try {
+            reader.parse(source);
+            fail();
+        } catch (IOException | SAXException ex) {
+            // expected an error
+        }
+    }
+
+    @Test
+    public void parseWithCatalog() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        config.setFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS, true);
+
+        ArrayList<String> catalogs = new ArrayList<>();
+        catalogs.add("src/test/resources/windows-catalog.xml");
+        config.setFeature(ResolverFeature.CATALOG_FILES, catalogs);
+
+        XMLResolver resolver = new XMLResolver(config);
+
+        ResolvingXMLReader reader = new ResolvingXMLReader(resolver);
+        InputSource source = new InputSource("src/test/resources/windows.xml");
+        try {
+            reader.parse(source);
+        } catch (IOException | SAXException ex) {
+            fail();
+        }
+
+
+    }
+
+}

--- a/src/test/resources/windows-catalog.xml
+++ b/src/test/resources/windows-catalog.xml
@@ -1,0 +1,5 @@
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog"
+         prefer="public">
+  <system systemId="\\hostname\xmlresolver\test\sample.dtd"
+          uri="sample10/sample.dtd"/>
+</catalog>

--- a/src/test/resources/windows.xml
+++ b/src/test/resources/windows.xml
@@ -1,0 +1,7 @@
+<!DOCTYPE book SYSTEM "\\hostname\xmlresolver\test\sample.dtd">
+<book xmlns="http://xmlresolver.org/ns/sample">
+<title>A sample book</title>
+<article>
+<p>Hello, world</p>
+</article>
+</book>


### PR DESCRIPTION
Fix #39 

The addition of the `ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS` feature and the decision that it applies irrespective of the platform made writing UNC path tests practical.

There's a bug fix here, too. If you put a UNC path in a system identifier (in the catalog), backslashes are now translated to forward slashes in the catalog entry. Consequently:

```xml
  <system systemId="\\hostname\xmlresolver\test\sample.dtd"
          uri="sample10/sample.dtd"/>
```

Stores `//hostname/xmlresolver/test/sample.dtd` internally. And that means that an attempt to resolve this DTD:

```xml
<!DOCTYPE book SYSTEM "\\hostname\xmlresolver\test\sample.dtd">
```

will succeed. (It's slashes will be fixed as well and then it'll match what's in the catalog.)