### PR TITLE
Fix #211 by assuring setSystemIdentifier is called

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ basename=xmlresolver
 
 # ************************************************
 # When this version number changes:
-resolverVersion=6.0.9
+resolverVersion=6.0.10
 # Also change the version number in overview.html
 # FIXME: figure out how to automate this.
 # ************************************************

--- a/src/main/java/org/xmlresolver/sources/ResolverSAXSource.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverSAXSource.java
@@ -27,6 +27,7 @@ public class ResolverSAXSource extends SAXSource implements ResolverResourceInfo
         resolvedURI = resp.getResolvedURI();
         statusCode = resp.getStatusCode();
         resolvedHeaders = resp.getHeaders();
+        setSystemId(resp.getResolvedURI().toString());
     }
 
     @Override

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -6,7 +6,7 @@ designed to work in the context of XML processes, resolving external
 identifiers for parsers and URIs for other processes (XML Schema
 validation, RELAX NG validation, transformations, querying etc.).</p>
 
-<p>This JavaDoc is for the version 6.0.9 API.</p>
+<p>This JavaDoc is for the version 6.0.10 API.</p>
 
 <p>By providing <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">an OASIS XML Catalog</a> file that maps URIs, for example,
 from web resources to local resources, you can improve the performance


### PR DESCRIPTION
The `ResolverSAXSource` now correctly sets the underlying `SAXSource` system identifier property.