### PR TITLE
Throw exception of access is denied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,18 +7,13 @@ plugins {
   id 'com.nwalsh.gradle.docker.container' version '0.0.5'
 }
 
-sourceCompatibility=1.8
-targetCompatibility=1.8
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
   mavenLocal()
   mavenCentral()
-}
-
-java {
-  registerFeature('validating') {
-    usingSourceSet(sourceSets.main)
-  }
 }
 
 jar {
@@ -37,21 +32,20 @@ configurations {
 
 dependencies {
   implementation (
-    [group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.1.3'],
-    [group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.1.3'],
+    [group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.3.1'],
+    [group: 'org.apache.httpcomponents.core5', name: 'httpcore5', version: '5.3.1'],
+    [group: 'xerces', name: 'xercesImpl', version: '2.12.2' ]
   )
 
   compileOnly (
-    [group: 'org.slf4j', name: 'slf4j-api', version: '1.7.36' ]
-  )
-
-  validatingImplementation (
-    [group: 'org.relaxng', name: 'jing', version: '20220510' ]
+    [group: 'org.slf4j', name: 'slf4j-api', version: '2.0.16' ],
+    [group: 'org.relaxng', name: 'jing', version: '20241231' ]
   )
 
   testImplementation (
     [group: 'junit', name: 'junit', version: '4.13.2'],
-    [group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36' ],
+    [group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.16' ],
+    [group: 'org.relaxng', name: 'jing', version: '20241231' ],
     // Because reasons: https://blog.adamretter.org.uk/xerces-xsd11-maven/
     [group: 'org.exist-db.thirdparty.xerces', name: 'xercesImpl', version: '2.12.2' ],
     files("src/test/resources/data1.jar"),
@@ -174,7 +168,7 @@ task dist(dependsOn: ["copyDocs", "copyJars", "test"], type: Zip) {
 }
 
 javadoc {
-  title 'XML Catalog Resolver API'
+  title = 'XML Catalog Resolver API'
   exclude 'org/xmlresolver/utils/**'
   exclude 'org/xmlresolver/BuildConfig.java'
   exclude 'org/xmlresolver/ResourceConnection.java'
@@ -308,7 +302,7 @@ clean.dependsOn deleteBuild
 // ======================================================================
 
 tasks.register("dockerup") {
-  description "Make sure the Docker container is running."
+  description = "Make sure the Docker container is running."
   doLast {
     if (!DockerContainer.running(c_restest)) {
       DockerContainer.compose {
@@ -323,7 +317,7 @@ tasks.register("dockerup") {
 test.dependsOn dockerup
 
 tasks.register("dockerdown") {
-  description "Make sure the Docker container is not running."
+  description = "Make sure the Docker container is not running."
   doLast {
     if (DockerContainer.running(c_restest)) {
       DockerContainer.compose {
@@ -336,7 +330,7 @@ tasks.register("dockerdown") {
 }
 
 tasks.register("dockerstatus") {
-  description "Print a short summary of running containers"
+  description = "Print a short summary of running containers"
   doLast {
     if (DockerContainer.containers().isEmpty()) {
       println("There are no docker containers running.")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 basename=xmlresolver
 
-resolverVersion=5.2.5
+resolverVersion=5.3.0
 
 group=org.xmlresolver
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/xmlresolver/CatalogManager.java
+++ b/src/main/java/org/xmlresolver/CatalogManager.java
@@ -109,6 +109,9 @@ public class CatalogManager implements XMLCatalogResolver {
         catalogLoader = loader;
     }
 
+    /** Return the catalog files.
+     * @return the list of catalog files
+     */
     public List<URI> catalogs() {
         ArrayList<URI> catlist = new ArrayList<>();
         for (String cat : resolverConfiguration.getFeature(ResolverFeature.CATALOG_FILES)) {

--- a/src/main/java/org/xmlresolver/CatalogResolver.java
+++ b/src/main/java/org/xmlresolver/CatalogResolver.java
@@ -99,8 +99,8 @@ public class CatalogResolver implements ResourceResolver {
             URI uri = new URI(href);
             if (uri.isAbsolute()) {
                 if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_DOCUMENT), href)) {
-                    logger.log(AbstractLogger.REQUEST, "resolveURI (access denied): null");
-                    return null;
+                    logger.log(AbstractLogger.REQUEST, "resolveURI (access denied): " + href);
+                    throw new IllegalArgumentException("Resource protocol access denied: " + href);
                 }
             }
         } catch (URISyntaxException ex) {
@@ -120,8 +120,8 @@ public class CatalogResolver implements ResourceResolver {
                 absolute = new URI(baseURI).resolve(href).toString();
                 if (!href.equals(absolute)) {
                     if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_DOCUMENT), absolute)) {
-                        logger.log(AbstractLogger.REQUEST, "resolveURI (access denied): null");
-                        return null;
+                        logger.log(AbstractLogger.REQUEST, "resolveURI (access denied): " + absolute);
+                        throw new IllegalArgumentException("Resource protocol access denied: " + absolute);
                     }
                     resolved = catalog.lookupURI(absolute);
                     if (resolved != null) {
@@ -229,8 +229,8 @@ public class CatalogResolver implements ResourceResolver {
                 URI uri = new URI(systemId);
                 if (uri.isAbsolute()) {
                     if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_ENTITY), systemId)) {
-                        logger.log(AbstractLogger.REQUEST, "resolveEntity (access denied): null");
-                        return null;
+                        logger.log(AbstractLogger.REQUEST, "resolveEntity (access denied): " + systemId);
+                        throw new IllegalArgumentException("Resource protocol access denied: " + systemId);
                     }
                 }
             } catch (URISyntaxException ex) {
@@ -274,8 +274,8 @@ public class CatalogResolver implements ResourceResolver {
                     }
 
                     if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_ENTITY), absSystem.toString())) {
-                        logger.log(AbstractLogger.REQUEST, "resolveEntity (access denied): null");
-                        return null;
+                        logger.log(AbstractLogger.REQUEST, "resolveEntity (access denied): " + absSystem);
+                        throw new IllegalArgumentException("Resource protocol access denied: " + absSystem);
                     }
 
                     resolved = catalog.lookupEntity(name, absSystem.toString(), publicId);
@@ -361,8 +361,8 @@ public class CatalogResolver implements ResourceResolver {
                 URI uri = new URI(baseURI);
                 if (uri.isAbsolute()) {
                     if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_ENTITY), baseURI)) {
-                        logger.log(AbstractLogger.REQUEST, "resolveEntity (access denied): null");
-                        return null;
+                        logger.log(AbstractLogger.REQUEST, "resolveEntity (access denied): " + baseURI);
+                        throw new IllegalArgumentException("Resource protocol access denied: " + baseURI);
                     }
                 }
             } catch (URISyntaxException ex) {
@@ -410,8 +410,8 @@ public class CatalogResolver implements ResourceResolver {
             absolute = new URI(uri);
             if (absolute.isAbsolute()) {
                 if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_DOCUMENT), uri)) {
-                    logger.log(AbstractLogger.REQUEST, "resolveNamespace (access denied): null");
-                    return null;
+                    logger.log(AbstractLogger.REQUEST, "resolveNamespace (access denied): " + uri);
+                    throw new IllegalArgumentException("Resource protocol access denied: " + uri);
                 }
             }
         } catch (URISyntaxException ex) {
@@ -433,8 +433,8 @@ public class CatalogResolver implements ResourceResolver {
 
                 if (absolute.isAbsolute()) {
                     if (forbidAccess(config.getFeature(ResolverFeature.ACCESS_EXTERNAL_DOCUMENT), uri)) {
-                        logger.log(AbstractLogger.REQUEST, "resolveNamespace (access denied): null");
-                        return null;
+                        logger.log(AbstractLogger.REQUEST, "resolveNamespace (access denied): " + uri);
+                        throw new IllegalArgumentException("Resource protocol access denied: " + uri);
                     }
                 }
 

--- a/src/main/java/org/xmlresolver/ResolverFeature.java
+++ b/src/main/java/org/xmlresolver/ResolverFeature.java
@@ -1,6 +1,5 @@
 package org.xmlresolver;
 
-import com.thaiopensource.resolver.xml.sax.SAX;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xmlresolver.cache.ResourceCache;

--- a/src/main/java/org/xmlresolver/package-info.java
+++ b/src/main/java/org/xmlresolver/package-info.java
@@ -6,7 +6,7 @@
  * perform redirection through RDDL documents and automated caching of
  * resources retrieved from the web.</p>
  *
- * <h1>TL;DR</h1>
+ * <h2>TL;DR</h2>
  *
  * <p>Tell your processor to instantiate a {@link org.xmlresolver.Resolver} (it has a zero argument constructor
  * so that it can be instantiated just from its name) and use it as the entity and URI resolver.</p>
@@ -14,7 +14,7 @@
  * <p>Tell your processor to instantiate a
  * {@link org.xmlresolver.tools.ResolvingXMLReader} for parsing.</p>
  *
- * <h1>L;OS (long; only skimmed)</h1>
+ * <h2>L;OS (long; only skimmed)</h2>
  *
  * <p>For most users, the principle entry points to this API will be the
  * {@link org.xmlresolver.Resolver} class and the {@link org.xmlresolver.tools.ResolvingXMLReader}. These instantiate
@@ -42,7 +42,7 @@
  * <p>The <code>ResolvingXMLReader</code> class extends the SAX parser so that
  * it will automatically construct and use a resolver.
  *
- * <h1>Accessing the resolver</h1>
+ * <h2>Accessing the resolver</h2>
  *
  * <p>The resolver is configured with a {@link org.xmlresolver.ResolverConfiguration}, more specifically
  * in this release, an {@link org.xmlresolver.XMLResolverConfiguration}. This class allows you to configure

--- a/src/test/java/org/xmlresolver/Jaxp185Test.java
+++ b/src/test/java/org/xmlresolver/Jaxp185Test.java
@@ -9,9 +9,7 @@ import javax.xml.transform.Source;
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class Jaxp185Test {
     public static final String catalog1 = "src/test/resources/jaxp185.xml";
@@ -105,7 +103,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttpsNotFake() {
         try {
             InputSource source = restrictedResolver.resolveEntity(null, "https://example.com/sample/1.0/sample.dtd");
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -115,7 +115,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttpNotFake() {
         try {
             InputSource source = restrictedResolver.resolveEntity(null, "http://example.com/sample/1.0/sample.dtd");
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -135,7 +137,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttpsNotFake() {
         try {
             Source source = restrictedResolver.resolve("https://example.com/sample/1.0/document.xml", null);
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -145,7 +149,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttpNotFake() {
         try {
             Source source = restrictedResolver.resolve("http://example.com/sample/1.0/document.xml", null);
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -195,7 +201,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttp() {
         try {
             InputSource source = allowHttpsResolver.resolveEntity(null, "http://example.com/sample/1.0/sample.dtd");
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -205,7 +213,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttps() {
         try {
             InputSource source = allowHttpResolver.resolveEntity(null, "https://example.com/sample/1.0/sample.dtd");
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -267,7 +277,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttp() {
         try {
             Source source = allowHttpsResolver.resolve("http://example.com/sample/1.0/document.xml", null);
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -277,7 +289,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttps() {
         try {
             Source source = allowHttpResolver.resolve("https://example.com/sample/1.0/document.xml", null);
-            assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }


### PR DESCRIPTION
Previous versions of the resolver would return null if access to a resource was denied (if, for example, only http: and https: URIs were allowed but a file: URI was requested). Unfortunately, returning null may be interpreted by the parser as a request to simply load the specified resource, bypassing the prohibition.

The only reliable way to avoid this problem is to throw an exception.