### PR TITLE
Throw exception of access is denied

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,13 +40,17 @@ configurations {
 }
 
 dependencies {
+  implementation (
+    [group: 'xerces', name: 'xercesImpl', version: '2.12.2']
+  )
+
   validatingImplementation (
-    [group: 'org.relaxng', name: 'jing', version: '20220510' ]
+    [group: 'org.relaxng', name: 'jing', version: '20241231' ]
   )
 
   docletImplementation (
-    [group: 'org.relaxng', name: 'jing', version: '20220510' ],
-    [group: 'com.saxonica', name: 'xmldoclet', version: '0.4.0']
+    [group: 'org.relaxng', name: 'jing', version: '20241231' ],
+    [group: 'com.saxonica', name: 'xmldoclet', version: '0.16.0']
   )
 
   testImplementation (

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ basename=xmlresolver
 
 # ************************************************
 # When this version number changes:
-resolverVersion=6.0.12
+resolverVersion=6.0.13
 # Also change the version number in overview.html
 # FIXME: figure out how to automate this.
 # ************************************************

--- a/src/main/java/org/xmlresolver/ResourceAccess.java
+++ b/src/main/java/org/xmlresolver/ResourceAccess.java
@@ -265,10 +265,11 @@ public class ResourceAccess {
         if (URIUtils.forbidAccess(accessList.concat(",file"), resourceURI.toString(), mergeHttps)) {
             if (request.isResolvingAsEntity()) {
                 logger.log(AbstractLogger.REQUEST, "resolveEntity, access denied: " + resourceURI);
+                throw new IllegalArgumentException("resolveEntity, access denied: " + resourceURI);
             } else {
                 logger.log(AbstractLogger.REQUEST, "resolveURI, access denied: " + resourceURI);
+                throw new IllegalArgumentException("resolveURI, access denied: " + resourceURI);
             }
-            return new ResourceResponseImpl(request, true);
         }
 
         ResourceConnection connx = new ResourceConnection(resourceURI);

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -6,7 +6,7 @@ designed to work in the context of XML processes, resolving external
 identifiers for parsers and URIs for other processes (XML Schema
 validation, RELAX NG validation, transformations, querying etc.).</p>
 
-<p>This JavaDoc is for the version 6.0.11 API.</p>
+<p>This JavaDoc is for the version 6.0.13 API.</p>
 
 <p>By providing <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">an OASIS XML Catalog</a> file that maps URIs, for example,
 from web resources to local resources, you can improve the performance

--- a/src/test/java/org/xmlresolver/Jaxp185Test.java
+++ b/src/test/java/org/xmlresolver/Jaxp185Test.java
@@ -104,7 +104,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttpsNotFake() {
         try {
             InputSource source = restrictedResolver.getEntityResolver().resolveEntity(null, "https://example.com/sample/1.0/sample.dtd");
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -114,7 +116,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttpNotFake() {
         try {
             InputSource source = restrictedResolver.getEntityResolver().resolveEntity(null, "http://example.com/sample/1.0/sample.dtd");
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -134,7 +138,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttpsNotFake() {
         try {
             Source source = restrictedResolver.getURIResolver().resolve("https://example.com/sample/1.0/document.xml", null);
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -144,7 +150,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttpNotFake() {
         try {
             Source source = restrictedResolver.getURIResolver().resolve("http://example.com/sample/1.0/document.xml", null);
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -194,7 +202,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttp() {
         try {
             InputSource source = allowHttpsResolver.getEntityResolver().resolveEntity(null, "http://example.com/sample/1.0/sample.dtd");
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -204,7 +214,9 @@ public class Jaxp185Test {
     public void lookupSystemFailHttps() {
         try {
             InputSource source = allowHttpResolver.getEntityResolver().resolveEntity(null, "https://example.com/sample/1.0/sample.dtd");
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (IOException | SAXException ex) {
             fail();
         }
@@ -282,7 +294,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttp() {
         try {
             Source source = allowHttpsResolver.getURIResolver().resolve("http://example.com/sample/1.0/document.xml", null);
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }
@@ -292,7 +306,9 @@ public class Jaxp185Test {
     public void lookupUriFailHttps() {
         try {
             Source source = allowHttpResolver.getURIResolver().resolve("https://example.com/sample/1.0/document.xml", null);
-            Assertions.assertNull(source);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            Assertions.assertTrue(ex.getMessage().contains("access denied"));
         } catch (Exception ex) {
             fail();
         }


### PR DESCRIPTION
Previous versions of the resolver would return null if access to a resource was denied (if, for example, only http: and https: URIs were allowed but a file: URI was requested). Unfortunately, returning null may be interpreted by the parser as a request to simply load the specified resource, bypassing the prohibition.

The only reliable way to avoid this problem is to throw an exception.

This PR also updates a few dependencies and fixes the debugging output issue.

Fix #224