### PR TITLE
Refactored the “always resolve” feature to avoid namespaces

### DIFF
--- a/src/main/java/org/xmlresolver/CatalogResolver.java
+++ b/src/main/java/org/xmlresolver/CatalogResolver.java
@@ -97,6 +97,9 @@ public class CatalogResolver {
      */
     public ResolvedResource resolveNamespace(String uri, String baseURI, String nature, String purpose) {
         ResourceRequest req = resolver.getRequest(uri, baseURI, nature, purpose);
+        // If we're attempting to resolve a namespace, don't return the namespace URI if we didn't
+        // find anything better. The namespace URI is almost never the right thing by itself.
+        req.setAlwaysResolve(false);
         ResourceResponse resp = resolver.resolve(req);
         if (resp.isResolved()) {
             return new ResolvedResource(resp);

--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -107,6 +107,9 @@ public class Resolver implements URIResolver, LSResourceResolver, EntityResolver
     @Override
     public Source resolveNamespace(String uri, String nature, String purpose) throws TransformerException {
         ResourceRequest req = resolver.getRequest(uri, nature, purpose);
+        // If we're attempting to resolve a namespace, don't return the namespace URI if we didn't
+        // find anything better. The namespace URI is almost never the right thing by itself.
+        req.setAlwaysResolve(false);
         return resolverAdapter(req);
     }
 
@@ -114,7 +117,7 @@ public class Resolver implements URIResolver, LSResourceResolver, EntityResolver
         ResourceResponse resp = resolver.resolve(req);
 
         if (!resp.isResolved()) {
-            if (!config.getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+            if (!req.isAlwaysResolve()) {
                 return null;
             }
             try {

--- a/src/main/java/org/xmlresolver/ResourceRequest.java
+++ b/src/main/java/org/xmlresolver/ResourceRequest.java
@@ -16,6 +16,21 @@ public interface ResourceRequest {
     ResolverConfiguration getConfiguration();
 
     /**
+     * Get the always resolve setting.
+     * <p>If always resolve is true, then the original URI will be retrieved if the lookup
+     * fails to find a local resource. It's initialized to the value of the
+     * {@link org.xmlresolver.ResolverFeature#ALWAYS_RESOLVE} feature.</p>
+     */
+    boolean isAlwaysResolve();
+
+    /**
+     * Set the always resolve setting.
+     * <p>If this flag is true, then the original URI will be retrieved if the lookup
+     * fails to find a local resource.</p>
+     */
+    void setAlwaysResolve(boolean always);
+
+    /**
      * The RDDL nature of the request.
      * @return the nature
      */

--- a/src/main/java/org/xmlresolver/ResourceRequestImpl.java
+++ b/src/main/java/org/xmlresolver/ResourceRequestImpl.java
@@ -23,6 +23,7 @@ public class ResourceRequestImpl implements ResourceRequest {
     private String encoding = null;
     private boolean openStream = true;
     private boolean resolveAsEntity = false;
+    private boolean alwaysResolve = false;
 
     /**
      * ResourceRequest constructor.
@@ -49,11 +50,22 @@ public class ResourceRequestImpl implements ResourceRequest {
 
         resolveAsEntity = ResolverConstants.EXTERNAL_ENTITY_NATURE.equals(nature)
                 || ResolverConstants.DTD_NATURE.equals(nature);
+        alwaysResolve = config.getFeature(ResolverFeature.ALWAYS_RESOLVE);
     }
 
     @Override
     public ResolverConfiguration getConfiguration() {
         return config;
+    }
+
+    @Override
+    public void setAlwaysResolve(boolean always) {
+        alwaysResolve = always;
+    }
+
+    @Override
+    public boolean isAlwaysResolve() {
+        return alwaysResolve;
     }
 
     @Override

--- a/src/main/java/org/xmlresolver/XMLResolver.java
+++ b/src/main/java/org/xmlresolver/XMLResolver.java
@@ -347,7 +347,7 @@ public class XMLResolver {
         }
 
         if (resolved == null) {
-            if (config.getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+            if (request.isAlwaysResolve()) {
                 if (absSystem == null) {
                     logger.log(AbstractLogger.RESPONSE, "lookupEntity: null");
                     return new ResourceResponseImpl(request);
@@ -409,7 +409,7 @@ public class XMLResolver {
         }
 
         if (resolved == null) {
-            if (config.getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+            if (request.isAlwaysResolve()) {
                 if (absSystem == null) {
                     logger.log(AbstractLogger.RESPONSE, "lookupUri: null");
                     return new ResourceResponseImpl(request);
@@ -460,7 +460,7 @@ public class XMLResolver {
             }
 
             if (!lookup.isResolved()) {
-                if (config.getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+                if (request.isAlwaysResolve()) {
                     return config.getResource(lookup);
                 } else {
                     return lookup;

--- a/src/main/java/org/xmlresolver/adapters/XercesXniAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/XercesXniAdapter.java
@@ -90,7 +90,7 @@ public class XercesXniAdapter implements XMLEntityResolver {
 
     private ResourceResponse safeOpenConnection(ResourceRequest request) {
         // This is "safe" in the weird sense that it doesn't throw a checked exception
-        if (resolver.getConfiguration().getFeature(ResolverFeature.ALWAYS_RESOLVE)) {
+        if (request.isAlwaysResolve()) {
             try {
                 return resolver.getConfiguration().getResource(request);
             } catch (URISyntaxException | IOException err) {


### PR DESCRIPTION
Fix #229

There’s an unfortunate interaction between the ResolverFeature.ALWAYS_RESOLVE feature and namespace URI lookup. Using a namespace URI to find, for example, a schema in the catalog, or via indirection with RDDL to find things online, makes sense. But, generally speaking, what’s located at the namespace URI is not a useful resource. It’s very often not even present.

This PR refactors how the “always resolve” feature is implemented so that it can be set on a per-request basis. By default, it’s the same as the global configuration setting, but when doing namespace URI lookup, we disable it.