### PR TITLE
Log the URI returned from a resource request

### DIFF
--- a/src/main/java/org/xmlresolver/ResourceAccess.java
+++ b/src/main/java/org/xmlresolver/ResourceAccess.java
@@ -58,7 +58,11 @@ public class ResourceAccess {
             uri = URIUtils.resolve(URIUtils.cwd(), uri.toString());
         }
 
-        return getResourceFromURI(request, uri);
+        ResourceResponse resp = getResourceFromURI(request, uri);
+
+        this.logger.log(AbstractLogger.RESPONSE, "getResource: " + resp.isResolved() + ": " + resp.getURI());
+
+        return resp;
     }
 
     /**
@@ -88,7 +92,11 @@ public class ResourceAccess {
             uri = URIUtils.resolve(URIUtils.cwd(), uri.toString());
         }
 
-        return getResourceFromURI(response.getRequest(), uri);
+        ResourceResponse resp = getResourceFromURI(response.getRequest(), uri);
+
+        this.logger.log(AbstractLogger.RESPONSE, "getResource: " + resp.isResolved() + ": " + resp.getURI());
+
+        return resp;
     }
 
     private ResourceResponse getResourceFromURI(ResourceRequest request, URI uri) throws URISyntaxException, IOException {


### PR DESCRIPTION
Fix #230

This avoids a slightly confusing log which says that lookup failed but then clearly did return a resource. This PR now logs the resource returned.