### PR TITLE
Make sure that catalog file are handled correctly on Windows

### DIFF
--- a/src/main/java/org/xmlresolver/utils/URIUtils.java
+++ b/src/main/java/org/xmlresolver/utils/URIUtils.java
@@ -208,6 +208,9 @@ public abstract class URIUtils {
             return null;
         }
 
+        // If this thing is a Windows path, fix that first.
+        uriref = windowsPathURI(uriref);
+
         StringBuilder newRef = new StringBuilder();
         byte[] bytes = uriref.getBytes(StandardCharsets.UTF_8);
 

--- a/src/test/iss0184/src/SBBVT0T-Deployment-Flat-mod.xml
+++ b/src/test/iss0184/src/SBBVT0T-Deployment-Flat-mod.xml
@@ -1,11 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE book SYSTEM "ymcsm2-4.dtd"[
-<!-- For some reason the unit test doesn't resolve the URI against
-     the correct base URI. So this is tweaked to pass. It's possible
-     that Xerces makes two attempts, first without resolving against
-     the base URI and the again resolved if necessary. But if the
-     first attempt doesn't succeed, the "\"s cause it to fail. -->
-<!ENTITY % gls.entities SYSTEM "src\test\iss0184\master\glossary\gls.ent">
+<!ENTITY % gls.entities SYSTEM "..\master\glossary\gls.ent">
 %gls.entities;
 ]>
 <book>&test;</book>

--- a/src/test/java/org/xmlresolver/CatalogLookupTest.java
+++ b/src/test/java/org/xmlresolver/CatalogLookupTest.java
@@ -41,6 +41,26 @@ public class CatalogLookupTest {
         assertNull(result);
     }
 
+    @Test
+    public void lookupAbsoluteCatalogFile() {
+        // This test checks that a catalog file passed in that starts at the root of the filesystem
+        // works correctly. Specifically, that on Windows, C:\path\catalog.xml doesn't get mangled
+        // into C:%2Fpath%2Fcatalog.xml or something worse.
+
+        config = new XMLResolverConfiguration(Collections.emptyList(), Collections.emptyList());
+
+        String cwd = System.getProperty("user.dir");
+        if (!cwd.endsWith("/") && !cwd.endsWith("\\")) {
+            cwd = cwd + "/";
+        }
+
+        config.setFeature(ResolverFeature.CATALOG_FILES, Arrays.asList(cwd + catalog1, cwd + catalog2));
+        config.setFeature(ResolverFeature.URI_FOR_SYSTEM, false);
+        manager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
+        URI result = manager.lookupSystem("https://example.com/sample/1.0/sample.dtd");
+        assertEquals(URIUtils.cwd().resolve(catalog1).resolve("sample10/sample-system.dtd"), result);
+    }
+
     // ============================================================
     // See https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html#attrib.prefer
     // Note that the N/A entries in column three are a bit misleading.

--- a/src/test/java/org/xmlresolver/Issue0184Test.java
+++ b/src/test/java/org/xmlresolver/Issue0184Test.java
@@ -5,17 +5,10 @@ import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xmlresolver.tools.ResolvingXMLReader;
-import org.xmlresolver.utils.PublicId;
 import org.xmlresolver.utils.URIUtils;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class Issue0184Test {
@@ -32,12 +25,32 @@ public class Issue0184Test {
 
     @Test
     public void parserTest() {
+        /*
+         * This test passes on Windows but cannot pass on Mac/Linux systems.
+         * Xerces doesn't resolve the system identifier against the base URI
+         * because it doesn't think it's a relative path. The resolver can
+         * sort out the slashes, but there's no catalog entry so it returns
+         * null and Xerces fails with "URI has no protocol". Setting ALWAYS_RESOLVE
+         * to true doesn't help because without the base URI, the resolver
+         * can't open it either.
+         */
+
+        if (!URIUtils.isWindows()) {
+            return;
+        }
+
         try {
             ResolvingXMLReader reader = new ResolvingXMLReader(resolver);
             // This test requires this feature!
             reader.getResolver().getConfiguration().setFeature(ResolverFeature.FIX_WINDOWS_SYSTEM_IDENTIFIERS, true);
+            reader.getResolver().getConfiguration().setFeature(ResolverFeature.ALWAYS_RESOLVE, true);
             String filename = "src/test/iss0184/src/SBBVT0T-Deployment-Flat-mod.xml";
             InputSource source = new InputSource(filename);
+            String cwd = URIUtils.cwd().getPath();
+            if (!cwd.endsWith("/")) {
+                cwd = cwd + "/";
+            }
+            source.setSystemId(cwd + filename);
             reader.parse(source);
         } catch (IOException | SAXException ex) {
             fail();


### PR DESCRIPTION
A catalog file of the form “C:\path\catalog.xml” is now correctly recognized on Windows and accepted as a file.

This PR also fixes the iss0184 test so that it passes on Windows and is ignored on other platforms. This is equivalent to, but slightly different from, the resolution on the 6.x branch.