### PR TITLE
Add a copy method to the ResolverConfiguration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ basename=xmlresolver
 
 # ************************************************
 # When this version number changes:
-resolverVersion=6.0.15
+resolverVersion=6.0.16
 # Also change the version number in overview.html
 # FIXME: figure out how to automate this.
 # ************************************************

--- a/src/main/java/org/xmlresolver/ResolverConfiguration.java
+++ b/src/main/java/org/xmlresolver/ResolverConfiguration.java
@@ -34,6 +34,17 @@ public interface ResolverConfiguration {
     public Iterator<ResolverFeature<?>> getFeatures();
 
     /**
+     * Returns a copy of the resolver configuration with independent catalogs.
+     *
+     * <p>Coping a configuration returns a new configuration with the same features, except
+     * that it has an independent set of catalogs. This allows an application to construct
+     * a new resolver with different catalogs but the same functionality.</p>
+     *
+     * @return a copy of the configuration
+     */
+    public ResolverConfiguration copy();
+
+    /**
      * Get a resource.
      * <p>This method takes a {@link ResourceRequest} and attempts to retrieve it.</p>
      * <p>The method should return a response indicating failure if it cannot retrieve the resource.

--- a/src/main/java/org/xmlresolver/ResourceRequest.java
+++ b/src/main/java/org/xmlresolver/ResourceRequest.java
@@ -20,6 +20,7 @@ public interface ResourceRequest {
      * <p>If always resolve is true, then the original URI will be retrieved if the lookup
      * fails to find a local resource. It's initialized to the value of the
      * {@link org.xmlresolver.ResolverFeature#ALWAYS_RESOLVE} feature.</p>
+     * @return true if always resolve is enabled
      */
     boolean isAlwaysResolve();
 
@@ -27,6 +28,7 @@ public interface ResourceRequest {
      * Set the always resolve setting.
      * <p>If this flag is true, then the original URI will be retrieved if the lookup
      * fails to find a local resource.</p>
+     * @param always sets always resolve
      */
     void setAlwaysResolve(boolean always);
 

--- a/src/main/java/org/xmlresolver/ResourceResponseImpl.java
+++ b/src/main/java/org/xmlresolver/ResourceResponseImpl.java
@@ -97,6 +97,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return connection;
     }
 
+    /**
+     * Set the content type of the response
+     * @param contentType the content type
+     */
     public void setContentType(String contentType) {
         this.contentType = contentType;
     }
@@ -106,6 +110,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return contentType;
     }
 
+    /**
+     * Set the response input stream.
+     * @param stream the stream.
+     */
     public void setInputStream(InputStream stream) {
         this.stream = stream;
     }
@@ -115,6 +123,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return stream;
     }
 
+    /**
+     * Set the response rejected value.
+     * @param rejected the value.
+     */
     public void setRejected(boolean rejected) {
         this.rejected = rejected;
     }
@@ -124,6 +136,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return rejected;
     }
 
+    /**
+     * Set the response resolved value.
+     * @param resolved the value.
+     */
     public void setResolved(boolean resolved) {
         this.resolved = resolved;
     }
@@ -133,6 +149,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return resolved;
     }
 
+    /**
+     * Set the response URI.
+     * @param uri the response URI
+     */
     public void setUri(URI uri) {
         this.uri = uri;
     }
@@ -142,6 +162,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return uri;
     }
 
+    /**
+     * Set the resolved URI.
+     * @param uri the resolved URI.
+     */
     public void setResolvedURI(URI uri) {
         resolvedURI = uri;
     }
@@ -162,6 +186,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return resolvedURI;
     }
 
+    /**
+     * Set the response encoding.
+     * @param encoding the encoding
+     */
     public void setEncoding(String encoding) {
         this.encoding = encoding;
     }
@@ -171,6 +199,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return encoding;
     }
 
+    /**
+     * Set the response headers.
+     * @param headers the headers.
+     */
     public void setHeaders(Map<String,List<String>> headers) {
         this.headers.clear();
         this.headers.putAll(headers);
@@ -200,6 +232,10 @@ public class ResourceResponseImpl implements ResourceResponse {
         return null;
     }
 
+    /**
+     * Set the response status code.
+     * @param code the status code
+     */
     public void setStatusCode(int code) {
         statusCode = code;
     }

--- a/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
+++ b/src/main/java/org/xmlresolver/XMLResolverConfiguration.java
@@ -278,44 +278,40 @@ public class XMLResolverConfiguration implements ResolverConfiguration {
         showConfigChanges = true;
     }
 
-    /** A copying constructor.
-     *
-     * <p>This constructor creates a new resolver configuration with the same properties
-     * as an existing configuration. It gets its own copy of the catalog file list and
-     * {@link CatalogManager}.</p>
-     *
-     * @param current The configuration to copy.
-     */
-    public XMLResolverConfiguration(XMLResolverConfiguration current) {
-        catalogs = new ArrayList<>(current.catalogs);
-        additionalCatalogs = new ArrayList<>();
-        classLoader = current.classLoader;
-        preferPublic = current.preferPublic;
-        preferPropertyFile = current.preferPropertyFile;
-        allowCatalogPI = current.allowCatalogPI;
-        alwaysResolve = current.alwaysResolve;
-        if (current.manager == null) {
-            manager = null;
-        } else {
-            manager = new CatalogManager(current.manager, this);
+    @Override
+    public ResolverConfiguration copy() {
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+
+        config.catalogs.addAll(catalogs);
+        config.additionalCatalogs.addAll(additionalCatalogs);
+        config.classLoader = classLoader;
+        config.preferPublic = preferPublic;
+        config.preferPropertyFile = preferPropertyFile;
+        config.allowCatalogPI = allowCatalogPI;
+        config.alwaysResolve = alwaysResolve;
+        config.uriForSystem = uriForSystem;
+        config.mergeHttps = mergeHttps;
+        config.maskJarUris = maskJarUris;
+        config.catalogLoader = catalogLoader;
+        config.parseRddl = parseRddl;
+        config.classpathCatalogs = classpathCatalogs;
+        config.archivedCatalogs = archivedCatalogs;
+        config.throwUriExceptions = throwUriExceptions;
+        config.showConfigChanges = showConfigChanges;
+        config.resolverLoggerClass = resolverLoggerClass;
+        config.resolverLogger = resolverLogger;
+        config.defaultLoggerLogLevel = defaultLoggerLogLevel;
+        config.accessExternalEntity = accessExternalEntity;
+        config.accessExternalDocument = accessExternalDocument;
+        config.saxParserFactoryClass = saxParserFactoryClass;
+        config.xmlReaderSupplier = xmlReaderSupplier;
+        config.fixWindowsSystemIdentifiers = fixWindowsSystemIdentifiers;
+
+        if (manager != null) {
+            config.manager = new CatalogManager(manager, config);
         }
-        uriForSystem = current.uriForSystem;
-        mergeHttps = current.mergeHttps;
-        maskJarUris = current.maskJarUris;
-        catalogLoader = current.catalogLoader;
-        parseRddl = current.parseRddl;
-        classpathCatalogs = current.classpathCatalogs;
-        archivedCatalogs = current.archivedCatalogs;
-        throwUriExceptions = current.throwUriExceptions;
-        showConfigChanges = current.showConfigChanges;
-        resolverLoggerClass = current.resolverLoggerClass;
-        resolverLogger = current.resolverLogger;
-        defaultLoggerLogLevel = current.defaultLoggerLogLevel;
-        accessExternalEntity = current.accessExternalEntity;
-        accessExternalDocument = current.accessExternalDocument;
-        saxParserFactoryClass = current.saxParserFactoryClass;
-        xmlReaderSupplier = current.xmlReaderSupplier;
-        fixWindowsSystemIdentifiers = current.fixWindowsSystemIdentifiers;
+
+        return config;
     }
 
     private String getConfigProperty(String name) {

--- a/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
+++ b/src/main/java/org/xmlresolver/tools/ResolvingXMLFilter.java
@@ -105,13 +105,7 @@ public class ResolvingXMLFilter extends XMLFilterImpl {
         try {
             if (allowXMLCatalogPI) {
                 // The parse may change the catalog list; isolate this configuration to this parse
-                ResolverConfiguration config = resolver.getConfiguration();
-                if (config instanceof XMLResolverConfiguration) {
-                    config = new XMLResolverConfiguration((XMLResolverConfiguration) config);
-                } else {
-                    logger.log(AbstractLogger.CONFIG, "Temporary configuration could not inherit from current configuration");
-                    config = new XMLResolverConfiguration();
-                }
+                ResolverConfiguration config = resolver.getConfiguration().copy();
                 resolver = new XMLResolver(config);
                 entityResolver = resolver.getEntityResolver2();
             }

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -6,7 +6,7 @@ designed to work in the context of XML processes, resolving external
 identifiers for parsers and URIs for other processes (XML Schema
 validation, RELAX NG validation, transformations, querying etc.).</p>
 
-<p>This JavaDoc is for the version 6.0.15 API.</p>
+<p>This JavaDoc is for the version 6.0.16 API.</p>
 
 <p>By providing <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">an OASIS XML Catalog</a> file that maps URIs, for example,
 from web resources to local resources, you can improve the performance

--- a/src/test/java/org/xmlresolver/ClasspathTest.java
+++ b/src/test/java/org/xmlresolver/ClasspathTest.java
@@ -92,7 +92,7 @@ public class ClasspathTest {
     public void testAlternateClassLoader() {
         String href = "classpath:path/example-doc.xml";
         ClassLoader loader = ClassLoader.getSystemClassLoader();
-        XMLResolverConfiguration localconfig = new XMLResolverConfiguration(config);
+        ResolverConfiguration localconfig = config.copy();
         localconfig.setFeature(ResolverFeature.CLASSLOADER, loader);
         XMLResolver localresolver = new XMLResolver(localconfig);
 


### PR DESCRIPTION
This is an interface change. It adds a copy() method to the ResolverConfiguration method and removes the then redundant copy constructor for XMLResolverConfiguration. There are also a few JavaDoc fixes.