### PR TITLE
Assure that responses are resolved against the request base URI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ basename=xmlresolver
 
 # ************************************************
 # When this version number changes:
-resolverVersion=6.0.16
+resolverVersion=6.0.17
 # Also change the version number in overview.html
 # FIXME: figure out how to automate this.
 # ************************************************

--- a/src/main/java/org/xmlresolver/ResourceAccess.java
+++ b/src/main/java/org/xmlresolver/ResourceAccess.java
@@ -89,7 +89,15 @@ public class ResourceAccess {
         }
 
         if (!uri.isAbsolute()) {
-            uri = URIUtils.resolve(URIUtils.cwd(), uri.toString());
+            // If the base URI is an absolute URI, we'll have worked out an absolute uri already
+            // So if the base URI exists, first make it absolute against the cwd().
+            // This means that a base URI of "/path/to/file" will be resolved correctly.
+            if (response.getRequest().getBaseURI() != null) {
+                URI base1 = URIUtils.resolve(URIUtils.cwd(), response.getRequest().getBaseURI());
+                uri = base1.resolve(uri.toString());
+            } else {
+                uri = URIUtils.resolve(URIUtils.cwd(), uri.toString());
+            }
         }
 
         ResourceResponse resp = getResourceFromURI(response.getRequest(), uri);

--- a/src/main/java/overview.html
+++ b/src/main/java/overview.html
@@ -6,7 +6,7 @@ designed to work in the context of XML processes, resolving external
 identifiers for parsers and URIs for other processes (XML Schema
 validation, RELAX NG validation, transformations, querying etc.).</p>
 
-<p>This JavaDoc is for the version 6.0.16 API.</p>
+<p>This JavaDoc is for the version 6.0.17 API.</p>
 
 <p>By providing <a href="https://www.oasis-open.org/committees/download.php/14809/xml-catalogs.html">an OASIS XML Catalog</a> file that maps URIs, for example,
 from web resources to local resources, you can improve the performance


### PR DESCRIPTION
Fix #248

If we find ourselves trying to get a resource from a response and the URI isn’t absolute, and the base URI of the request also isn’t absolute, resolve the base URI of the request against the current working directory, then the relative URI against that. This is more likely to be correct.