### PR TITLE
Use unmasked URIs for RDDL; also, disable RDDL parsing by default

### DIFF
--- a/src/main/java/org/xmlresolver/ResolverFeature.java
+++ b/src/main/java/org/xmlresolver/ResolverFeature.java
@@ -220,7 +220,7 @@ public class ResolverFeature<T> {
             "http://xmlresolver.org/feature/catalog-loader-class", "org.xmlresolver.loaders.XmlLoader");
 
     /**
-     * Controls whether or not namespace documents will be parsed for RDDL annotations.
+     * Controls whether namespace documents will be parsed for RDDL annotations.
      *
      * <p>If this feature is enabled, then if an attempt to get a namespace returns an HTML document,
      * and if a nature and purpose has been specified in the request, the HTML document will be parsed
@@ -230,10 +230,10 @@ public class ResolverFeature<T> {
      * Schema or RELAX NG namespace, the purpose is assumed to be validation.</p>
      */
     public static final ResolverFeature<Boolean> PARSE_RDDL = new ResolverFeature<>(
-            "http://xmlresolver.org/feature/rddl", true);
+            "http://xmlresolver.org/feature/rddl", false);
 
     /**
-     * Determines whether or not catalogs on the classpath should be loaded automatically.
+     * Determines whether catalogs on the classpath should be loaded automatically.
      *
      * <p>If this feature is enabled, then the resolver will attempt to find and load all
      * of the catalogs named <code>org/xmlresolver/catalog.xml</code> on the classpath.
@@ -246,7 +246,7 @@ public class ResolverFeature<T> {
      * Identify the ClassLoader to use for accessing resources on the classpath.
      *
      * <p>A {@link ClassLoader} is used to access the class path and load resources
-     * from the class path. By default the resolver configuration uses the class
+     * from the class path. By default, the resolver configuration uses the class
      * loader obtained from the class:</p>
      *
      * <pre>getClass().getClassLoader()</pre>

--- a/src/main/java/org/xmlresolver/XMLResolver.java
+++ b/src/main/java/org/xmlresolver/XMLResolver.java
@@ -479,7 +479,8 @@ public class XMLResolver {
     }
 
     private ResourceResponse rddlLookup(ResourceResponse lookup) {
-        return rddlLookup(lookup, lookup.getResolvedURI());
+        // Ignore masked jar URIs here, we want the actual resolved resource.
+        return rddlLookup(lookup, lookup.getUnmaskedURI());
     }
 
     private ResourceResponse rddlLookup(ResourceResponse lookup, URI resolved) {


### PR DESCRIPTION
Fix #253

By default jar: URIs are masked. If a resource is resolved locally, but the resolved location is in a jar: file, we return the original URI not the resolved URI. This is necessary because Java.net.URI doesn’t understand jar: URIs. (Oh, the irony.)

Unfortunately, when the RDDL parser asked for the resolved URI, it got back the original too. So it would go attempt to parse the “real” location not the resolved resource. That’s been fixed. It now parses the unmasked URI, not the resolved URI.

This is also the second bug (I think) caused by RDDL parsing. With some regret, I’m going to disable RDDL parsing by default. That means it will get used far, far less often, but since it’s not widely supported, that probably won’t have a huge impact. If you’re relying on it, remember to enable it.