### PR TITLE
Handle the case where a system identifier is null

### DIFF
--- a/src/main/java/org/xmlresolver/Resolver.java
+++ b/src/main/java/org/xmlresolver/Resolver.java
@@ -132,7 +132,9 @@ public class Resolver implements URIResolver, LSResourceResolver, EntityResolver
 
         if (resp.isResolved()) {
             ResolverSAXSource source = new ResolverSAXSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
             return source;
         }
 
@@ -181,7 +183,9 @@ public class Resolver implements URIResolver, LSResourceResolver, EntityResolver
         ResourceResponse resp = resolver.resolve(req);
         if (resp.isResolved()) {
             ResolverInputSource source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
             return source;
         }
 
@@ -196,7 +200,9 @@ public class Resolver implements URIResolver, LSResourceResolver, EntityResolver
         ResourceResponse resp = resolver.resolve(req);
         if (resp.isResolved()) {
             ResolverInputSource source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
             return source;
         }
 

--- a/src/main/java/org/xmlresolver/XMLResolver.java
+++ b/src/main/java/org/xmlresolver/XMLResolver.java
@@ -550,7 +550,9 @@ public class XMLResolver {
             Source source = null;
             if (resp.isResolved()) {
                 source = new ResolverSAXSource(resp);
-                source.setSystemId(resp.getURI().toString());
+                if (resp.getURI() != null) {
+                    source.setSystemId(resp.getURI().toString());
+                    }
             }
 
             return source;

--- a/src/main/java/org/xmlresolver/adapters/SAX1Adapter.java
+++ b/src/main/java/org/xmlresolver/adapters/SAX1Adapter.java
@@ -40,7 +40,9 @@ public class SAX1Adapter implements EntityResolver {
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
         }
 
         return source;

--- a/src/main/java/org/xmlresolver/adapters/SAX2Adapter.java
+++ b/src/main/java/org/xmlresolver/adapters/SAX2Adapter.java
@@ -40,17 +40,23 @@ public class SAX2Adapter implements EntityResolver2 {
         request.setEntityName(name);
         ResourceResponse resp = resolver.resolve(request);
 
+        if (resp == null) {
+            return null;
+        }
+
         // If we didn't find any resource in the catalog, and if ResolverFeature.ALWAYS_RESOLVE is true,
         // the default, then we'll be trying to return the baseURI as the external subset. That's
         // incoherent, so don't.
-        if (resp != null && resp.isResolved() && baseURI != null && baseURI.equals(resp.getURI().toString())) {
+        if (resp.isResolved() && baseURI != null && baseURI.equals(resp.getURI().toString())) {
             return null;
         }
 
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
         }
 
         return source;
@@ -66,7 +72,9 @@ public class SAX2Adapter implements EntityResolver2 {
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
         }
 
         return source;

--- a/src/main/java/org/xmlresolver/adapters/SAXAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/SAXAdapter.java
@@ -50,7 +50,9 @@ public class SAXAdapter implements EntityResolver, EntityResolver2 {
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
         }
 
         return source;
@@ -66,7 +68,9 @@ public class SAXAdapter implements EntityResolver, EntityResolver2 {
         ResolverInputSource source = null;
         if (resp.isResolved()) {
             source = new ResolverInputSource(resp);
-            source.setSystemId(resp.getResolvedURI().toString());
+            if (resp.getResolvedURI() != null) {
+                source.setSystemId(resp.getResolvedURI().toString());
+            }
         }
 
         return source;

--- a/src/main/java/org/xmlresolver/adapters/XercesXniAdapter.java
+++ b/src/main/java/org/xmlresolver/adapters/XercesXniAdapter.java
@@ -171,7 +171,9 @@ public class XercesXniAdapter implements XMLEntityResolver {
 
         if (rsrc != null && rsrc.isResolved()) {
             InputSource source = new ResolverInputSource(rsrc);
-            source.setSystemId(rsrc.getResolvedURI().toString());
+            if (rsrc.getResolvedURI() != null) {
+                source.setSystemId(rsrc.getResolvedURI().toString());
+            }
             return new SAXInputSource(source);
         }
 

--- a/src/main/java/org/xmlresolver/sources/ResolverInputSource.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverInputSource.java
@@ -23,7 +23,9 @@ public class ResolverInputSource extends InputSource implements ResolverResource
      * */
     public ResolverInputSource(ResourceResponse rsrc) {
         super(rsrc.getInputStream());
-        setSystemId(rsrc.getURI().toString());
+        if (rsrc.getURI() != null) {
+            setSystemId(rsrc.getURI().toString());
+        }
         setPublicId(rsrc.getRequest().getPublicId());
         this.response = rsrc;
         resolvedURI = rsrc.getResolvedURI();

--- a/src/main/java/org/xmlresolver/sources/ResolverLSInput.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverLSInput.java
@@ -36,7 +36,11 @@ public class ResolverLSInput implements LSInput, ResolverResourceInfo {
         resolvedURI = resp.getResolvedURI();
         this.response = resp;
         this.body = resp.getInputStream();
-        this.systemId = resp.getResolvedURI().toString();
+        if (resp.getResolvedURI() == null) {
+            this.systemId = null;
+        } else {
+            this.systemId = resp.getResolvedURI().toString();
+        }
         this.publicId = publicId;
         this.uri = resp.getURI();
         this.statusCode = resp.getStatusCode();

--- a/src/main/java/org/xmlresolver/sources/ResolverSAXSource.java
+++ b/src/main/java/org/xmlresolver/sources/ResolverSAXSource.java
@@ -26,7 +26,9 @@ public class ResolverSAXSource extends SAXSource implements ResolverResourceInfo
         resolvedURI = resp.getResolvedURI();
         statusCode = resp.getStatusCode();
         resolvedHeaders = resp.getHeaders();
-        setSystemId(resp.getResolvedURI().toString());
+        if (resp.getResolvedURI() != null) {
+            setSystemId(resp.getResolvedURI().toString());
+        }
     }
 
     @Override

--- a/src/test/java/org/xmlresolver/Issue262Test.java
+++ b/src/test/java/org/xmlresolver/Issue262Test.java
@@ -1,0 +1,81 @@
+package org.xmlresolver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class Issue262Test {
+    @Test
+    public void issue262a() {
+        try {
+            XMLResolverConfiguration config = new XMLResolverConfiguration();
+            config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
+            config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "debug");
+            config.setFeature(ResolverFeature.CATALOG_FILES, List.of("classpath:/iss262.xml"));
+            EntityResolver resolver = new Resolver(config);
+
+            InputSource source = resolver.resolveEntity("-//EXAMPLE//TEST//EN", null);
+            Assertions.assertNull(source.getSystemId());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void issue262b() {
+        try {
+            XMLResolverConfiguration config = new XMLResolverConfiguration();
+            config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
+            config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "debug");
+            config.setFeature(ResolverFeature.CATALOG_FILES, List.of("classpath:/iss262.xml"));
+            config.setFeature(ResolverFeature.MASK_JAR_URIS, false);
+            EntityResolver resolver = new Resolver(config);
+
+            InputSource source = resolver.resolveEntity("-//EXAMPLE//TEST//EN", null);
+            Assertions.assertNotNull(source.getSystemId());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void issue262c() {
+        try {
+            XMLResolverConfiguration config = new XMLResolverConfiguration();
+            config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
+            config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "debug");
+            config.setFeature(ResolverFeature.CATALOG_FILES, List.of("classpath:/iss262.xml"));
+            XMLResolver resolver = new XMLResolver(config);
+
+            InputSource source = resolver.getEntityResolver().resolveEntity("-//EXAMPLE//TEST//EN", null);
+            Assertions.assertNull(source.getSystemId());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
+
+    @Test
+    public void issue262d() {
+        try {
+            XMLResolverConfiguration config = new XMLResolverConfiguration();
+            config.setFeature(ResolverFeature.PREFER_PUBLIC, true);
+            config.setFeature(ResolverFeature.DEFAULT_LOGGER_LOG_LEVEL, "debug");
+            config.setFeature(ResolverFeature.CATALOG_FILES, List.of("classpath:/iss262.xml"));
+            XMLResolver resolver = new XMLResolver(config);
+
+            InputSource source = resolver.getEntityResolver2().resolveEntity("-//EXAMPLE//TEST//EN", null);
+            Assertions.assertNull(source.getSystemId());
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            fail();
+        }
+    }
+}

--- a/src/test/resources/iss262.dtd
+++ b/src/test/resources/iss262.dtd
@@ -1,0 +1,1 @@
+<!ELEMENT test EMPTY>

--- a/src/test/resources/iss262.xml
+++ b/src/test/resources/iss262.xml
@@ -1,0 +1,3 @@
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+  <public publicId="-//EXAMPLE//TEST//EN" uri="iss262.dtd"/>
+</catalog>


### PR DESCRIPTION
Fix #262

This can’t actually happen when parsing an XML document because system identifiers are always required. But the resolver and catalogs both support lookup only by public identifier, so don’t NPE when someone does that!